### PR TITLE
Add / 48 Abort Script Strategy Logic When Concat Scripts Present

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -336,7 +336,7 @@ class WP_Scripts extends WP_Dependencies {
 			// Get the most eligible loading strategy for said script handle.
 			// Used as a conditional to prevent script concatenation.
 			$strategy                    = $this->get_eligible_loading_strategy( $handle );
-			$is_deferred_or_async_handle = '' !== $strategy;
+			$is_deferred_or_async_handle = in_array( $strategy, array( 'defer', 'async' ), true );
 
 			if ( $this->in_default_dir( $srce ) && ( $before_handle || $after_handle || $translations_stop_concat || $is_deferred_or_async_handle ) ) {
 				$this->do_concat = false;

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -358,10 +358,8 @@ class WP_Scripts extends WP_Dependencies {
 			 */
 			$srce = apply_filters( 'script_loader_src', $src, $handle );
 
-			// Get the most eligible loading strategy for said script handle.
 			// Used as a conditional to prevent script concatenation.
-			$strategy                    = $this->get_eligible_loading_strategy( $handle );
-			$is_deferred_or_async_handle = '' !== $strategy;
+			$is_deferred_or_async_handle = in_array( $strategy, array( 'defer', 'async' ), true );
 
 			if ( $this->in_default_dir( $srce ) && ( $before_handle || $after_handle || $translations_stop_concat || $is_deferred_or_async_handle ) ) {
 				$this->do_concat = false;

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -517,7 +517,7 @@ class WP_Scripts extends WP_Dependencies {
 				$initial_type_attr = $this->type_attr;
 				$this->type_attr   = " type='text/template'";
 				printf(
-					'<script%1$s id=\'%2$s-js-after\' type=\'text/template\' data-wp-executes-after=\'%2$s\'>%5$s%4$s%5$s</script>%5$s',
+					'<script%1$s id=\'%2$s-js-after\' data-wp-executes-after=\'%2$s\'>%5$s%4$s%5$s</script>%5$s',
 					$this->type_attr,
 					esc_attr( $handle ),
 					esc_attr( $position ),

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -333,7 +333,12 @@ class WP_Scripts extends WP_Dependencies {
 			 */
 			$srce = apply_filters( 'script_loader_src', $src, $handle );
 
-			if ( $this->in_default_dir( $srce ) && ( $before_handle || $after_handle || $translations_stop_concat ) ) {
+			// Get the most eligible loading strategy for said script handle.
+			// Used as a conditional tp prevent script concatenation.
+			$strategy                    = $this->get_eligible_loading_strategy( $handle );
+			$is_deferred_or_async_handle = '' !== $strategy;
+
+			if ( $this->in_default_dir( $srce ) && ( $before_handle || $after_handle || $translations_stop_concat || $is_deferred_or_async_handle ) ) {
 				$this->do_concat = false;
 
 				// Have to print the so-far concatenated scripts right away to maintain the right order.

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -329,8 +329,6 @@ class WP_Scripts extends WP_Dependencies {
 					PHP_EOL
 				);
 				$this->type_attr   = $initial_type_attr;
-
-				$this->has_load_later_inline = true;
 			}
 		}
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -334,7 +334,7 @@ class WP_Scripts extends WP_Dependencies {
 			$srce = apply_filters( 'script_loader_src', $src, $handle );
 
 			// Get the most eligible loading strategy for said script handle.
-			// Used as a conditional tp prevent script concatenation.
+			// Used as a conditional to prevent script concatenation.
 			$strategy                    = $this->get_eligible_loading_strategy( $handle );
 			$is_deferred_or_async_handle = '' !== $strategy;
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1853,8 +1853,8 @@ function wp_print_template_loader_script() {
 		$output = <<<JS
 let wpLoadAfterScripts = ( handle ) => {
 	let scripts = document.querySelectorAll(`[type="text/template"][data-wp-executes-after="\${handle}"]`);
-	scripts.forEach( (script) => { 
-		script.setAttribute("type","text/javascript"); 
+	scripts.forEach( (script) => {
+		script.setAttribute("type","text/javascript");
 		eval(script.innerHTML);
 	})
 }

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -638,7 +638,7 @@ EXP;
 		wp_enqueue_script( 'one-concat-dep-1', $this->default_scripts_dir . 'script.js' );
 		wp_enqueue_script( 'two-concat-dep-1', $this->default_scripts_dir . 'script.js' );
 		wp_enqueue_script( 'three-concat-dep-1', $this->default_scripts_dir . 'script.js' );
-		wp_enqueue_script( 'main-defer-script-1', '/main-script.js', array(), null, array( 'strategy' => 'async' ) );
+		wp_enqueue_script( 'main-async-script-1', '/main-script.js', array(), null, array( 'strategy' => 'async' ) );
 
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
@@ -648,7 +648,7 @@ EXP;
 
 		$ver       = get_bloginfo( 'version' );
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$ver}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-1-js' async></script>\n";
+		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-async-script-1-js' async></script>\n";
 
 		$this->assertSame( $expected, $print_scripts );
 	}

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -587,6 +587,32 @@ EXP;
 	}
 
 	/**
+	 * Test script concatenation with deferred main script.
+	 *
+	 * @ticket 12009
+	 */
+	public function test_concatenate_with_defer_strategy() {
+		global $wp_scripts;
+
+		$wp_scripts->do_concat    = true;
+		$wp_scripts->default_dirs = array( '/directory/' );
+
+		wp_register_script( 'one-concat-dep', '/directory/script.js' );
+		wp_register_script( 'two-concat-dep', '/directory/script.js' );
+		wp_register_script( 'three-concat-dep', '/directory/script.js' );
+		wp_enqueue_script( 'main-defer-script', '/main-script.js', array( 'one-concat-dep', 'two-concat-dep', 'three-concat-dep' ), null, array( 'strategy' => 'defer' ) );
+
+		wp_print_scripts();
+		$print_scripts = get_echo( '_print_scripts' );
+
+		$ver      = get_bloginfo( 'version' );
+		$expected = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$ver}'></script>\n";
+		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer></script>\n";
+
+		$this->assertSame( $expected, $print_scripts );
+	}
+
+	/**
 	 * @ticket 42804
 	 */
 	public function test_wp_enqueue_script_with_html5_support_does_not_contain_type_attribute() {

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -14,6 +14,9 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 
 	protected $wp_scripts_print_translations_output;
 
+	// Stores a string reference to a default scripts directory name, utilised by certain tests.
+	protected $default_scripts_dir = '/directory/';
+
 	public function set_up() {
 		parent::set_up();
 		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
@@ -79,8 +82,8 @@ JS;
 <script id='wp-executes-after-js'>
 let wpLoadAfterScripts = ( handle ) => {
 	let scripts = document.querySelectorAll(`[type="text/template"][data-wp-executes-after="\${handle}"]`);
-	scripts.forEach( (script) => { 
-		script.setAttribute("type","text/javascript"); 
+	scripts.forEach( (script) => {
+		script.setAttribute("type","text/javascript");
 		eval(script.innerHTML);
 	})
 }
@@ -167,8 +170,8 @@ EXP;
 <script id='wp-executes-after-js'>
 let wpLoadAfterScripts = ( handle ) => {
 	let scripts = document.querySelectorAll(`[type="text/template"][data-wp-executes-after="\${handle}"]`);
-	scripts.forEach( (script) => { 
-		script.setAttribute("type","text/javascript"); 
+	scripts.forEach( (script) => {
+		script.setAttribute("type","text/javascript");
 		eval(script.innerHTML);
 	})
 }
@@ -190,8 +193,8 @@ EXP;
 <script id='wp-executes-after-js'>
 let wpLoadAfterScripts = ( handle ) => {
 	let scripts = document.querySelectorAll(`[type="text/template"][data-wp-executes-after="\${handle}"]`);
-	scripts.forEach( (script) => { 
-		script.setAttribute("type","text/javascript"); 
+	scripts.forEach( (script) => {
+		script.setAttribute("type","text/javascript");
 		eval(script.innerHTML);
 	})
 }
@@ -598,11 +601,11 @@ EXP;
 		$concatenate_scripts = true;
 
 		$wp_scripts->do_concat    = true;
-		$wp_scripts->default_dirs = array( '/directory/' );
+		$wp_scripts->default_dirs = array( $this->default_scripts_dir );
 
-		wp_register_script( 'one-concat-dep', '/directory/script.js' );
-		wp_register_script( 'two-concat-dep', '/directory/script.js' );
-		wp_register_script( 'three-concat-dep', '/directory/script.js' );
+		wp_register_script( 'one-concat-dep', $this->default_scripts_dir . 'script.js' );
+		wp_register_script( 'two-concat-dep', $this->default_scripts_dir . 'script.js' );
+		wp_register_script( 'three-concat-dep', $this->default_scripts_dir . 'script.js' );
 		wp_enqueue_script( 'main-defer-script', '/main-script.js', array( 'one-concat-dep', 'two-concat-dep', 'three-concat-dep' ), null, array( 'strategy' => 'defer' ) );
 
 		wp_print_scripts();
@@ -630,11 +633,11 @@ EXP;
 		$concatenate_scripts = true;
 
 		$wp_scripts->do_concat    = true;
-		$wp_scripts->default_dirs = array( '/directory/' );
+		$wp_scripts->default_dirs = array( $this->default_scripts_dir );
 
-		wp_enqueue_script( 'one-concat-dep-1', '/directory/script.js' );
-		wp_enqueue_script( 'two-concat-dep-1', '/directory/script.js' );
-		wp_enqueue_script( 'three-concat-dep-1', '/directory/script.js' );
+		wp_enqueue_script( 'one-concat-dep-1', $this->default_scripts_dir . 'script.js' );
+		wp_enqueue_script( 'two-concat-dep-1', $this->default_scripts_dir . 'script.js' );
+		wp_enqueue_script( 'three-concat-dep-1', $this->default_scripts_dir . 'script.js' );
 		wp_enqueue_script( 'main-defer-script-1', '/main-script.js', array(), null, array( 'strategy' => 'async' ) );
 
 		wp_print_scripts();
@@ -651,7 +654,7 @@ EXP;
 	}
 
 	/**
-	 * Test script concatenation with blocking scripts before and after a `defer` script. 
+	 * Test script concatenation with blocking scripts before and after a `defer` script.
 	 *
 	 * @ticket 12009
 	 */
@@ -662,15 +665,15 @@ EXP;
 		$concatenate_scripts = true;
 
 		$wp_scripts->do_concat    = true;
-		$wp_scripts->default_dirs = array( '/directory/' );
+		$wp_scripts->default_dirs = array( $this->default_scripts_dir );
 
-		wp_enqueue_script( 'one-concat-dep-2', '/directory/script.js' );
-		wp_enqueue_script( 'two-concat-dep-2', '/directory/script.js' );
-		wp_enqueue_script( 'three-concat-dep-2', '/directory/script.js' );
+		wp_enqueue_script( 'one-concat-dep-2', $this->default_scripts_dir . 'script.js' );
+		wp_enqueue_script( 'two-concat-dep-2', $this->default_scripts_dir . 'script.js' );
+		wp_enqueue_script( 'three-concat-dep-2', $this->default_scripts_dir . 'script.js' );
 		wp_enqueue_script( 'deferred-script-2', '/main-script.js', array(), null, array( 'strategy' => 'defer' ) );
-		wp_enqueue_script( 'four-concat-dep-2', '/directory/script.js' );
-		wp_enqueue_script( 'five-concat-dep-2', '/directory/script.js' );
-		wp_enqueue_script( 'six-concat-dep-2', '/directory/script.js' );
+		wp_enqueue_script( 'four-concat-dep-2', $this->default_scripts_dir . 'script.js' );
+		wp_enqueue_script( 'five-concat-dep-2', $this->default_scripts_dir . 'script.js' );
+		wp_enqueue_script( 'six-concat-dep-2', $this->default_scripts_dir . 'script.js' );
 
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
@@ -754,11 +757,11 @@ EXP;
 		global $wp_scripts;
 
 		$wp_scripts->do_concat    = true;
-		$wp_scripts->default_dirs = array( '/directory/' );
+		$wp_scripts->default_dirs = array( $this->default_scripts_dir );
 
-		wp_enqueue_script( 'one', '/directory/script.js' );
-		wp_enqueue_script( 'two', '/directory/script.js' );
-		wp_enqueue_script( 'three', '/directory/script.js' );
+		wp_enqueue_script( 'one', $this->default_scripts_dir . 'script.js' );
+		wp_enqueue_script( 'two', $this->default_scripts_dir . 'script.js' );
+		wp_enqueue_script( 'three', $this->default_scripts_dir . 'script.js' );
 
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
@@ -1151,21 +1154,21 @@ EXP;
 		global $wp_scripts;
 
 		$wp_scripts->do_concat    = true;
-		$wp_scripts->default_dirs = array( '/directory/' );
+		$wp_scripts->default_dirs = array( $this->default_scripts_dir );
 
-		wp_enqueue_script( 'one', '/directory/one.js' );
-		wp_enqueue_script( 'two', '/directory/two.js' );
-		wp_enqueue_script( 'three', '/directory/three.js' );
+		wp_enqueue_script( 'one', $this->default_scripts_dir . 'one.js' );
+		wp_enqueue_script( 'two', $this->default_scripts_dir . 'two.js' );
+		wp_enqueue_script( 'three', $this->default_scripts_dir . 'three.js' );
 
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 		wp_add_inline_script( 'two', 'console.log("before two");', 'before' );
 
 		$ver       = get_bloginfo( 'version' );
 		$expected  = "<script type='text/javascript' id='one-js-before'>\nconsole.log(\"before one\");\n</script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/one.js?ver={$ver}' id='one-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}one.js?ver={$ver}' id='one-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='two-js-before'>\nconsole.log(\"before two\");\n</script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/two.js?ver={$ver}' id='two-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/three.js?ver={$ver}' id='three-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$ver}' id='two-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$ver}' id='three-js'></script>\n";
 
 		$this->assertSame( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -1177,19 +1180,19 @@ EXP;
 		global $wp_scripts;
 
 		$wp_scripts->do_concat    = true;
-		$wp_scripts->default_dirs = array( '/directory/' );
+		$wp_scripts->default_dirs = array( $this->default_scripts_dir );
 
-		wp_enqueue_script( 'one', '/directory/one.js' );
-		wp_enqueue_script( 'two', '/directory/two.js' );
-		wp_enqueue_script( 'three', '/directory/three.js' );
+		wp_enqueue_script( 'one', $this->default_scripts_dir . 'one.js' );
+		wp_enqueue_script( 'two', $this->default_scripts_dir . 'two.js' );
+		wp_enqueue_script( 'three', $this->default_scripts_dir . 'three.js' );
 
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 
 		$ver       = get_bloginfo( 'version' );
 		$expected  = "<script type='text/javascript' id='one-js-before'>\nconsole.log(\"before one\");\n</script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/one.js?ver={$ver}' id='one-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/two.js?ver={$ver}' id='two-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/three.js?ver={$ver}' id='three-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}one.js?ver={$ver}' id='one-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$ver}' id='two-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$ver}' id='three-js'></script>\n";
 
 		$this->assertSame( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -1201,23 +1204,23 @@ EXP;
 		global $wp_scripts;
 
 		$wp_scripts->do_concat    = true;
-		$wp_scripts->default_dirs = array( '/directory/' );
+		$wp_scripts->default_dirs = array( $this->default_scripts_dir );
 
-		wp_enqueue_script( 'one', '/directory/one.js' );
-		wp_enqueue_script( 'two', '/directory/two.js' );
-		wp_enqueue_script( 'three', '/directory/three.js' );
-		wp_enqueue_script( 'four', '/directory/four.js' );
+		wp_enqueue_script( 'one', $this->default_scripts_dir . 'one.js' );
+		wp_enqueue_script( 'two', $this->default_scripts_dir . 'two.js' );
+		wp_enqueue_script( 'three', $this->default_scripts_dir . 'three.js' );
+		wp_enqueue_script( 'four', $this->default_scripts_dir . 'four.js' );
 
 		wp_add_inline_script( 'two', 'console.log("after two");' );
 		wp_add_inline_script( 'three', 'console.log("after three");' );
 
 		$ver       = get_bloginfo( 'version' );
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one&amp;ver={$ver}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/two.js?ver={$ver}' id='two-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$ver}' id='two-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='two-js-after'>\nconsole.log(\"after two\");\n</script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/three.js?ver={$ver}' id='three-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$ver}' id='three-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='three-js-after'>\nconsole.log(\"after three\");\n</script>\n";
-		$expected .= "<script type='text/javascript' src='/directory/four.js?ver={$ver}' id='four-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}four.js?ver={$ver}' id='four-js'></script>\n";
 
 		$this->assertSame( $expected, get_echo( 'wp_print_scripts' ) );
 	}

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -605,9 +605,35 @@ EXP;
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
 
-		$ver      = get_bloginfo( 'version' );
-		$expected = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$ver}'></script>\n";
+		$ver       = get_bloginfo( 'version' );
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer></script>\n";
+
+		$this->assertSame( $expected, $print_scripts );
+	}
+
+	/**
+	 * Test script concatenation with `async` main script.
+	 *
+	 * @ticket 12009
+	 */
+	public function test_concatenate_with_async_strategy() {
+		global $wp_scripts;
+
+		$wp_scripts->do_concat    = true;
+		$wp_scripts->default_dirs = array( '/directory/' );
+
+		wp_enqueue_script( 'one-concat-dep-1', '/directory/script.js' );
+		wp_enqueue_script( 'two-concat-dep-1', '/directory/script.js' );
+		wp_enqueue_script( 'three-concat-dep-1', '/directory/script.js' );
+		wp_enqueue_script( 'main-defer-script-1', '/main-script.js', array(), null, array( 'strategy' => 'async' ) );
+
+		wp_print_scripts();
+		$print_scripts = get_echo( '_print_scripts' );
+
+		$ver       = get_bloginfo( 'version' );
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$ver}'></script>\n";
+		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-1-js' async></script>\n";
 
 		$this->assertSame( $expected, $print_scripts );
 	}

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -592,7 +592,10 @@ EXP;
 	 * @ticket 12009
 	 */
 	public function test_concatenate_with_defer_strategy() {
-		global $wp_scripts;
+		global $wp_scripts, $concatenate_scripts;
+
+		$old_value = $concatenate_scripts;
+		$concatenate_scripts = true;
 
 		$wp_scripts->do_concat    = true;
 		$wp_scripts->default_dirs = array( '/directory/' );
@@ -604,6 +607,9 @@ EXP;
 
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
+
+		// reset global before asserting.
+		$concatenate_scripts = $old_value;
 
 		$ver       = get_bloginfo( 'version' );
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$ver}'></script>\n";
@@ -618,7 +624,10 @@ EXP;
 	 * @ticket 12009
 	 */
 	public function test_concatenate_with_async_strategy() {
-		global $wp_scripts;
+		global $wp_scripts, $concatenate_scripts;
+
+		$old_value = $concatenate_scripts;
+		$concatenate_scripts = true;
 
 		$wp_scripts->do_concat    = true;
 		$wp_scripts->default_dirs = array( '/directory/' );
@@ -631,9 +640,47 @@ EXP;
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
 
+		// reset global before asserting.
+		$concatenate_scripts = $old_value;
+
 		$ver       = get_bloginfo( 'version' );
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-1-js' async></script>\n";
+
+		$this->assertSame( $expected, $print_scripts );
+	}
+
+	/**
+	 * Test script concatenation with blocking scripts before and after a `defer` script. 
+	 *
+	 * @ticket 12009
+	 */
+	public function test_concatenate_with_blocking_script_before_and_after_script_with_defer_strategy() {
+		global $wp_scripts, $concatenate_scripts;
+
+		$old_value = $concatenate_scripts;
+		$concatenate_scripts = true;
+
+		$wp_scripts->do_concat    = true;
+		$wp_scripts->default_dirs = array( '/directory/' );
+
+		wp_enqueue_script( 'one-concat-dep-2', '/directory/script.js' );
+		wp_enqueue_script( 'two-concat-dep-2', '/directory/script.js' );
+		wp_enqueue_script( 'three-concat-dep-2', '/directory/script.js' );
+		wp_enqueue_script( 'deferred-script-2', '/main-script.js', array(), null, array( 'strategy' => 'defer' ) );
+		wp_enqueue_script( 'four-concat-dep-2', '/directory/script.js' );
+		wp_enqueue_script( 'five-concat-dep-2', '/directory/script.js' );
+		wp_enqueue_script( 'six-concat-dep-2', '/directory/script.js' );
+
+		wp_print_scripts();
+		$print_scripts = get_echo( '_print_scripts' );
+
+		// reset global before asserting.
+		$concatenate_scripts = $old_value;
+
+		$ver       = get_bloginfo( 'version' );
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-2,two-concat-dep-2,three-concat-dep-2,four-concat-dep-2,five-concat-dep-2,six-concat-dep-2&amp;ver={$ver}'></script>\n";
+		$expected .= "<script type='text/javascript' src='/main-script.js' id='deferred-script-2-js' defer></script>\n";
 
 		$this->assertSame( $expected, $print_scripts );
 	}

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -597,7 +597,7 @@ EXP;
 	public function test_concatenate_with_defer_strategy() {
 		global $wp_scripts, $concatenate_scripts;
 
-		$old_value = $concatenate_scripts;
+		$old_value           = $concatenate_scripts;
 		$concatenate_scripts = true;
 
 		$wp_scripts->do_concat    = true;
@@ -629,7 +629,7 @@ EXP;
 	public function test_concatenate_with_async_strategy() {
 		global $wp_scripts, $concatenate_scripts;
 
-		$old_value = $concatenate_scripts;
+		$old_value           = $concatenate_scripts;
 		$concatenate_scripts = true;
 
 		$wp_scripts->do_concat    = true;
@@ -661,7 +661,7 @@ EXP;
 	public function test_concatenate_with_blocking_script_before_and_after_script_with_defer_strategy() {
 		global $wp_scripts, $concatenate_scripts;
 
-		$old_value = $concatenate_scripts;
+		$old_value           = $concatenate_scripts;
 		$concatenate_scripts = true;
 
 		$wp_scripts->do_concat    = true;


### PR DESCRIPTION
Fixes #48 

- Aborts script concatenation per handle and resets `$this->do_concat` if the handle in question is of a `defer` or `async` loading strategy.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
