### PR TITLE
Eliminate manual construction of `script` tags

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -123,15 +123,16 @@ class WP_Scripts extends WP_Dependencies {
 	public $default_dirs;
 
 	/**
-	 * Holds a string which contains the type attribute for script tag.
+	 * Whether script tags should be generated as HTML5.
 	 *
 	 * If the active theme does not declare HTML5 support for 'script',
-	 * then it initializes as `type='text/javascript'`.
+	 * then scripts are output with `type='text/javascript'`.
 	 *
 	 * @since 5.3.0
-	 * @var string
+	 * @since 6.3.0 Renamed from type_attr to is_html5.
+	 * @var bool
 	 */
-	private $type_attr = '';
+	private $is_html5 = true;
 
 	/**
 	 * Holds a mapping of dependents (as handles) for a given script handle.
@@ -163,7 +164,7 @@ class WP_Scripts extends WP_Dependencies {
 		&&
 			function_exists( 'current_theme_supports' ) && ! current_theme_supports( 'html5', 'script' )
 		) {
-			$this->type_attr = " type='text/javascript'";
+			$this->is_html5 = false;
 		}
 
 		/**
@@ -236,16 +237,16 @@ class WP_Scripts extends WP_Dependencies {
 			return $output;
 		}
 
-		printf( "<script%s id='%s-js-extra'>\n", $this->type_attr, esc_attr( $handle ) );
+		printf( "<script%s id='%s-js-extra'>\n", $this->is_html5 ? '' : " type='text/javascript'", esc_attr( $handle ) );
 
 		// CDATA is not needed for HTML 5.
-		if ( $this->type_attr ) {
+		if ( ! $this->is_html5 ) {
 			echo "/* <![CDATA[ */\n";
 		}
 
 		echo "$output\n";
 
-		if ( $this->type_attr ) {
+		if ( ! $this->is_html5 ) {
 			echo "/* ]]> */\n";
 		}
 
@@ -306,7 +307,7 @@ class WP_Scripts extends WP_Dependencies {
 		$before_handle = $this->print_inline_script( $handle, 'before', false );
 
 		if ( $before_handle ) {
-			$before_handle = sprintf( "<script%s id='%s-js-before'>\n%s\n</script>\n", $this->type_attr, esc_attr( $handle ), $before_handle );
+			$before_handle = sprintf( "<script%s id='%s-js-before'>\n%s\n</script>\n", $this->is_html5 ? '' : " type='text/javascript'", esc_attr( $handle ), $before_handle );
 		}
 
 		// Eligible loading strategies will only be 'async', 'defer', or ''.
@@ -317,7 +318,7 @@ class WP_Scripts extends WP_Dependencies {
 		if ( $after_handle ) {
 			$after_handle = sprintf(
 				"<script%1\$s id='%2\$s-js-after'>\n%3\$s\n</script>\n",
-				$this->type_attr,
+				$this->is_html5 ? '' : " type='text/javascript'",
 				esc_attr( $handle ),
 				$after_handle
 			);
@@ -348,7 +349,7 @@ class WP_Scripts extends WP_Dependencies {
 
 		$translations = $this->print_translations( $handle, false );
 		if ( $translations ) {
-			$translations = sprintf( "<script%s id='%s-js-translations'>\n%s\n</script>\n", $this->type_attr, esc_attr( $handle ), $translations );
+			$translations = sprintf( "<script%s id='%s-js-translations'>\n%s\n</script>\n", $this->is_html5 ? '' : " type='text/javascript'", esc_attr( $handle ), $translations );
 		}
 
 		if ( $this->do_concat ) {
@@ -434,7 +435,7 @@ class WP_Scripts extends WP_Dependencies {
 		$tag  = $translations . $cond_before . $before_handle;
 		$tag .= sprintf(
 			"<script%s src='%s' id='%s-js'%s></script>\n",
-			$this->type_attr,
+			$this->is_html5 ? '' : " type='text/javascript'",
 			esc_url( $src ),
 			esc_attr( $handle ),
 			$strategy
@@ -527,7 +528,7 @@ class WP_Scripts extends WP_Dependencies {
 
 			printf(
 				$script_output,
-				$this->type_attr,
+				$this->is_html5 ? '' : " type='text/javascript'",
 				esc_attr( $handle ),
 				esc_attr( $position ),
 				$output
@@ -693,7 +694,7 @@ class WP_Scripts extends WP_Dependencies {
 JS;
 
 		if ( $display ) {
-			printf( "<script%s id='%s-js-translations'>\n%s\n</script>\n", $this->type_attr, esc_attr( $handle ), $output );
+			printf( "<script%s id='%s-js-translations'>\n%s\n</script>\n", $this->is_html5 ? '' : " type='text/javascript'", esc_attr( $handle ), $output );
 		}
 
 		return $output;

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -219,9 +219,7 @@ class WP_Scripts extends WP_Dependencies {
 
 		wp_print_inline_script_tag(
 			$output,
-			array(
-				'id' => "{$handle}-js-extra",
-			)
+			array( 'id' => "{$handle}-js-extra" )
 		);
 
 		return true;
@@ -293,9 +291,7 @@ class WP_Scripts extends WP_Dependencies {
 		if ( $after_handle ) {
 			$after_handle = wp_get_inline_script_tag(
 				$after_handle,
-				array(
-					'id' => "{$handle}-js-after",
-				)
+				array( 'id' => "{$handle}-js-after" )
 			);
 		}
 		if ( '' !== $strategy ) {
@@ -671,9 +667,7 @@ JS;
 		if ( $display ) {
 			wp_print_inline_script_tag(
 				$output,
-				array(
-					'id' => "{$handle}-js-translations",
-				)
+				array( 'id' => "{$handle}-js-translations" )
 			);
 		}
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -123,18 +123,6 @@ class WP_Scripts extends WP_Dependencies {
 	public $default_dirs;
 
 	/**
-	 * Whether script tags should be generated as HTML5.
-	 *
-	 * If the active theme does not declare HTML5 support for 'script',
-	 * then scripts are output with `type='text/javascript'`.
-	 *
-	 * @since 5.3.0
-	 * @since 6.3.0 Renamed from type_attr to is_html5.
-	 * @var bool
-	 */
-	private $is_html5 = true;
-
-	/**
 	 * Holds a mapping of dependents (as handles) for a given script handle.
 	 * Used to optimize recursive dependency tree checks.
 	 *
@@ -159,14 +147,6 @@ class WP_Scripts extends WP_Dependencies {
 	 * @since 3.4.0
 	 */
 	public function init() {
-		if (
-			function_exists( 'is_admin' ) && ! is_admin()
-		&&
-			function_exists( 'current_theme_supports' ) && ! current_theme_supports( 'html5', 'script' )
-		) {
-			$this->is_html5 = false;
-		}
-
 		/**
 		 * Fires when the WP_Scripts instance is initialized.
 		 *

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -411,8 +411,11 @@ class WP_Scripts extends WP_Dependencies {
 			'src' => $src,
 			'id'  => "{$handle}-js",
 		);
-		if ( '' !== $strategy && ! empty( $after_non_standalone_handle ) ) {
-			$attributes['onload'] = sprintf( 'wpLoadAfterScripts(%s)', wp_json_encode( $handle ) );
+		if ( '' !== $strategy ) {
+			$attributes[ $strategy ] = true;
+			if ( ! empty( $after_non_standalone_handle ) ) {
+				$attributes['onload'] = sprintf( 'wpLoadAfterScripts(%s)', wp_json_encode( $handle ) );
+			}
 		}
 		$tag  = $translations . $cond_before . $before_handle;
 		$tag .= wp_get_script_tag( $attributes );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2794,7 +2794,8 @@ function wp_sanitize_script_attributes( $attributes ) {
  * @return string String containing `<script>` opening and closing tags.
  */
 function wp_get_script_tag( $attributes ) {
-	if ( ! isset( $attributes['type'] ) && ! is_admin() && ! current_theme_supports( 'html5', 'script' ) ) {
+	$is_html5 = is_admin() || current_theme_supports( 'html5', 'script' );
+	if ( ! isset( $attributes['type'] ) && ! $is_html5 ) {
 		$attributes['type'] = 'text/javascript';
 	}
 	/**
@@ -2838,7 +2839,8 @@ function wp_print_script_tag( $attributes ) {
  * @return string String containing inline JavaScript code wrapped around `<script>` tag.
  */
 function wp_get_inline_script_tag( $javascript, $attributes = array() ) {
-	if ( ! isset( $attributes['type'] ) && ! is_admin() && ! current_theme_supports( 'html5', 'script' ) ) {
+	$is_html5 = is_admin() || current_theme_supports( 'html5', 'script' );
+	if ( ! isset( $attributes['type'] ) && ! $is_html5 ) {
 		$attributes['type'] = 'text/javascript';
 	}
 	/**
@@ -2854,6 +2856,11 @@ function wp_get_inline_script_tag( $javascript, $attributes = array() ) {
 	$attributes = apply_filters( 'wp_inline_script_attributes', $attributes, $javascript );
 
 	$javascript = "\n" . trim( $javascript, "\n\r " ) . "\n";
+
+	// Add CDATA comments if not HTML 5.
+	if ( ! $is_html5 ) {
+		$javascript = "\n/* <![CDATA[ */{$javascript}/* ]]> */\n";
+	}
 
 	return sprintf( "<script%s>%s</script>\n", wp_sanitize_script_attributes( $attributes ), $javascript );
 }


### PR DESCRIPTION
Amends ~https://github.com/10up/wordpress-develop/pull/54~ https://github.com/WordPress/wordpress-develop/pull/4391

This eliminates manual construction of `script` tags from `WP_Scripts` methods. It replaces manual construction with `wp_print_inline_script_tag()`, `wp_get_inline_script_tag()`, and `wp_get_script_tag()` (which were [added](https://make.wordpress.org/core/2021/02/23/introducing-script-attributes-related-functions-in-wordpress-5-7/) in WP 5.7). Doing so makes the code much more readable as well as more robust by automatically escaping attribute values and allowing the `wp_script_attributes` and `wp_inline_script_attributes` filters to apply to the attributes being printed. It also ensures the non-HTML5 CDATA wrapper comments are added consistently. This would seem to be a logical follow-up to [Core-39941](https://core.trac.wordpress.org/ticket/39941) which introduced these functions but didn't make use of them in `WP_Scripts`. This will facilitate adding CSP attributes to scripts that core prints. (I'm not sure why this wasn't done as part of the aforementioned Trac ticket.)

- [ ] Update tests to account for changes in output (where double quotes are used instead of single, attribute order is changed, and CDATA wrappers are added when not in HTML5)