### PR TITLE
Conditionally skip lazy-loading on images before the loop in classic themes (Trac: 58211)

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3646,6 +3646,8 @@ class WP_Query {
 		$this->in_the_loop = true;
 
 		if ( -1 == $this->current_post ) { // Loop has just started.
+			$this->before_loop = false;
+
 			/**
 			 * Fires once the loop is started.
 			 *
@@ -3684,6 +3686,8 @@ class WP_Query {
 			// Do some cleaning up after the loop.
 			$this->rewind_posts();
 		} elseif ( 0 === $this->post_count ) {
+			$this->before_loop = false;
+
 			/**
 			 * Fires if no results are found in a post query.
 			 *

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -109,6 +109,14 @@ class WP_Query {
 	public $current_post = -1;
 
 	/**
+	 * Whether the caller is before the loop.
+	 *
+	 * @since 6.3.0
+	 * @var bool
+	 */
+	public $before_loop = true;
+
+	/**
 	 * Whether the loop has started and the caller is in the loop.
 	 *
 	 * @since 2.0.0

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5461,8 +5461,9 @@ function wp_get_loading_attr_default( $context ) {
 
 	// Conditionally skip lazy-loading on images before the loop.
 	if ( 'wp_get_attachment_image' === $context || 'the_post_thumbnail' === $context ) {
-		// Any image before header ends should not be lazy load.
+		// Only apply for main query but before the loop.
 		if ( $wp_query->before_loop && is_main_query() ) {
+			// Any image before header ends should not be lazy load.
 			$is_header_loaded = did_action( 'get_header' ) && ! doing_action( 'get_header' );
 			if ( ! $is_header_loaded ) {
 				return false;

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5461,14 +5461,17 @@ function wp_get_loading_attr_default( $context ) {
 
 	// Conditionally skip lazy-loading on images before the loop.
 	if ( 'wp_get_attachment_image' === $context || 'the_post_thumbnail' === $context ) {
-		// Any image before loop should not lazy load.
-		if ( $wp_query->before_loop && is_main_query() && did_action( 'get_header' ) && ! doing_action( 'get_header' ) ) {
-			// If footer has alredy reached then it means the current template did not include any loop. Lazy-load image from this point.
-			if ( did_action( 'get_footer' ) || doing_action( 'get_footer' ) ) {
-				return 'lazy';
+		// Any image before header ends should not be lazy load.
+		if ( $wp_query->before_loop && is_main_query() ) {
+			$is_header_loaded = did_action( 'get_header' ) && ! doing_action( 'get_header' );
+			if ( ! $is_header_loaded ) {
+				return false;
 			}
 
-			return false;
+			// If footer has alredy reached then it means the current template did not include any loop. Lazy-load image from this point.
+			if ( did_action( 'get_footer' ) ) {
+				return 'lazy';
+			}
 		}
 	}
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5459,7 +5459,7 @@ function wp_get_loading_attr_default( $context ) {
 		return false;
 	}
 
-	//
+	// Conditionally skip lazy-loading on images before the loop.
 	if ( 'wp_get_attachment_image' === $context || 'the_post_thumbnail' === $context ) {
 		// Any image before loop should not lazy load.
 		if ( $wp_query->before_loop && is_main_query() && did_action( 'get_header' ) && ! doing_action( 'get_header' ) ) {

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3711,13 +3711,13 @@ EOF;
 	}
 
 	/**
-	 * Tests that wp_get_loading_attr_default() returns the expected loading attribute value.
+	 * Tests that wp_get_loading_attr_default() returns the expected loading attribute value before loop.
 	 *
 	 * @ticket 58211
 	 *
 	 * @covers ::wp_get_loading_attr_default
 	 *
-	 * @dataProvider data_wp_get_loading_attr_default_before_loop
+	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
 	 *
 	 * @param string $context
 	 */
@@ -3755,7 +3755,47 @@ EOF;
 		}
 	}
 
-	public function data_wp_get_loading_attr_default_before_loop() {
+	/**
+	 * Tests that wp_get_loading_attr_default() returns the expected loading attribute if no loop.
+	 *
+	 * @ticket 58211
+	 *
+	 * @covers ::wp_get_loading_attr_default
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @param string $context
+	 */
+	public function test_wp_get_loading_attr_default_no_loop( $context ) {
+		global $wp_query, $wp_the_query;
+
+		$wp_query = new WP_Query( array( 'post__in' => array( self::$post_ids['publish'] ) ) );
+		$this->reset_content_media_count();
+		$this->reset_omit_loading_attr_filter();
+
+		// Set current query as main query.
+		$wp_the_query = $wp_query;
+
+		// Ensure header is called already.
+		do_action( 'get_header' );
+
+		// if footer called before loop.
+		add_action(
+			'get_footer',
+			function() use ( $context ) {
+				$this->assertSame( 'lazy', wp_get_loading_attr_default( $context ) );
+			}
+		);
+		do_action( 'get_footer' );
+		$this->assertSame( 'lazy', wp_get_loading_attr_default( $context ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_get_loading_attr_default_before_and_no_loop() {
 		return array(
 			array( 'wp_get_attachment_image' ),
 			array( 'the_post_thumbnail' ),

--- a/tests/phpunit/tests/media/getAdjacentImageLink.php
+++ b/tests/phpunit/tests/media/getAdjacentImageLink.php
@@ -32,7 +32,7 @@ class Tests_Media_GetAdjacentImageLink extends WP_Test_Adjacent_Image_Link_TestC
 			'when has previous link'           => array(
 				'current_attachment_index'  => 3,
 				'expected_attachment_index' => 2,
-				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image2.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" loading="lazy" /></a>',
+				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image2.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" /></a>',
 			),
 			'with text when has previous link' => array(
 				'current_attachment_index'  => 3,
@@ -43,7 +43,7 @@ class Tests_Media_GetAdjacentImageLink extends WP_Test_Adjacent_Image_Link_TestC
 			'when has next link'               => array(
 				'current_attachment_index'  => 4,
 				'expected_attachment_index' => 5,
-				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image5.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" loading="lazy" /></a>',
+				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image5.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" /></a>',
 				'args'                      => array( 'prev' => false ),
 			),
 			'with text when has next link'     => array(

--- a/tests/phpunit/tests/media/getNextImageLink.php
+++ b/tests/phpunit/tests/media/getNextImageLink.php
@@ -31,7 +31,7 @@ class Tests_Media_GetNextImageLink extends WP_Test_Adjacent_Image_Link_TestCase 
 			'when has next link'           => array(
 				'current_attachment_index'  => 4,
 				'expected_attachment_index' => 5,
-				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image5.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" loading="lazy" /></a>',
+				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image5.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" /></a>',
 			),
 			'with text when has next link' => array(
 				'current_attachment_index'  => 4,

--- a/tests/phpunit/tests/media/getPreviousImageLink.php
+++ b/tests/phpunit/tests/media/getPreviousImageLink.php
@@ -31,7 +31,7 @@ class Tests_Media_GetPreviousImageLink extends WP_Test_Adjacent_Image_Link_TestC
 			'when has previous link'           => array(
 				'current_attachment_index'  => 3,
 				'expected_attachment_index' => 2,
-				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image2.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" loading="lazy" /></a>',
+				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image2.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" /></a>',
 			),
 			'with text when has previous link' => array(
 				'current_attachment_index'  => 3,

--- a/tests/phpunit/tests/media/nextImageLink.php
+++ b/tests/phpunit/tests/media/nextImageLink.php
@@ -30,7 +30,7 @@ class Tests_Media_NextImageLink extends WP_Test_Adjacent_Image_Link_TestCase {
 			'when has next link'           => array(
 				'current_attachment_index'  => 4,
 				'expected_attachment_index' => 5,
-				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image5.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" loading="lazy" /></a>',
+				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image5.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" /></a>',
 			),
 			'with text when has next link' => array(
 				'current_attachment_index'  => 4,

--- a/tests/phpunit/tests/media/previousImageLink.php
+++ b/tests/phpunit/tests/media/previousImageLink.php
@@ -30,7 +30,7 @@ class Tests_Media_PreviousImageLink extends WP_Test_Adjacent_Image_Link_TestCase
 			'when has previous link'           => array(
 				'current_attachment_index'  => 3,
 				'expected_attachment_index' => 2,
-				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image2.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" loading="lazy" /></a>',
+				'expected'                  => '<a href=\'http://example.org/?attachment_id=%%ID%%\'><img width="1" height="1" src="' . WP_CONTENT_URL . '/uploads/image2.jpg" class="attachment-thumbnail size-thumbnail" alt="" decoding="async" /></a>',
 			),
 			'with text when has previous link' => array(
 				'current_attachment_index'  => 3,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [https://core.trac.wordpress.org/ticket/58211](https://core.trac.wordpress.org/ticket/58211)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
