### PR TITLE
Core PR Iteration - Add Test Coverage Indicators & Failure Messages for Enhancing The WP Scripts API With a Loading Strategy

### DIFF
--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -514,6 +514,10 @@ EXP;
 	 * Test invalid async loading strategy cases.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_invalid_async_registration() {
 		// If any dependencies then it's not async. Since dependency is blocking(/defer) final strategy will be defer.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -434,6 +434,11 @@ EXP;
 	 * any inline script associated with the main script.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_standalone_before_inline_script_with_defer_main_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -105,7 +105,7 @@ console.log("after two");
 </script>
 
 EXP;
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, __( 'Inline scripts in the "after" position, both standalone and non standalone, are failing to print/execute or printing/executing in the incorrect order.' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -525,14 +525,14 @@ EXP;
 		wp_enqueue_script( 'main-script-a2', '/main-script-a2.js', array( 'dependency-script-a2' ), null, array( 'strategy' => 'async' ) );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = "<script type='text/javascript' src='/main-script-a2.js' id='main-script-a2-js' defer></script>";
-		$this->assertStringContainsString( $expected, $output, 'Expected defer.' );
+		$this->assertStringContainsString( $expected, $output, 'Scripts registered as async but that have dependencies are expected to be deferred.' );
 
 		// If any dependent then it's not async. Since dependent is not set to defer the final strategy will be blocking.
 		wp_enqueue_script( 'main-script-a3', '/main-script-a3.js', array(), null, array( 'strategy' => 'async' ) );
 		wp_enqueue_script( 'dependent-script-a3', '/dependent-script-a3.js', array( 'main-script-a3' ), null );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = "<script type='text/javascript' src='/main-script-a3.js' id='main-script-a3-js'></script>";
-		$this->assertStringContainsString( $expected, $output, 'Expected blocking.' );
+		$this->assertStringContainsString( $expected, $output, 'Scripts registered as async but that have dependents that are blocking are expected to be blocking themselves.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -74,6 +74,8 @@ JS;
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::print_inline_script
 	 * @covers ::wp_print_delayed_inline_script_loader
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_and_standalone_after_script_combined() {
 		// If a main script containing a `defer` strategy has an `after` inline script, the expected script type is type='javascript', otherwise type='text/template'.
@@ -120,6 +122,7 @@ EXP;
 	 * @covers WP_Scripts::print_inline_script
 	 * @covers ::wp_print_delayed_inline_script_loader
 	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_standalone_after_inline_script_with_defer_main_script() {
 		unregister_all_script_handles();
@@ -145,6 +148,7 @@ EXP;
 	 * @covers WP_Scripts::print_inline_script
 	 * @covers ::wp_print_delayed_inline_script_loader
 	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_standalone_after_inline_script_with_async_main_script() {
 		unregister_all_script_handles();
@@ -500,6 +504,7 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_async_registration() {
@@ -517,6 +522,7 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_invalid_async_registration() {
@@ -543,6 +549,7 @@ EXP;
 	 * @dataProvider data_loading_strategy_with_valid_defer_registration
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_defer_registration( $expected, $output, $message ) {
@@ -591,6 +598,7 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_defer_with_async_dependent() {
@@ -615,6 +623,7 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_invalid_defer_registration() {
@@ -635,6 +644,7 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_blocking_registration() {
@@ -748,6 +758,8 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_normalized_script_args
+	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers WP_Scripts::is_valid_strategy
 	 * @covers ::wp_enqueue_script
 	 * @covers ::wp_register_script
 	 */

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -744,6 +744,11 @@ EXP;
 	 * For an invalid strategy defined during script registration, default to a blocking strategy.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_normalized_script_args
+	 * @covers ::wp_enqueue_script
+	 * @covers ::wp_register_script
 	 */
 	public function test_script_strategy_doing_it_wrong() {
 		$this->setExpectedIncorrectUsage( 'WP_Scripts::get_intended_strategy' );

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -696,6 +696,7 @@ EXP;
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
+	 * @covers ::wp_register_script
 	 */
 	public function test_get_normalized_script_args() {
 		global $wp_scripts;

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -797,7 +797,7 @@ EXP;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer></script>\n";
 
-		$this->assertSame( $expected, $print_scripts, 'Scripts are being incorrectly concatenated when a main script is registered with a "defer" loading strategy.');
+		$this->assertSame( $expected, $print_scripts, 'Scripts are being incorrectly concatenated when a main script is registered with a "defer" loading strategy.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -394,11 +394,16 @@ EXP;
 	}
 
 	/**
-	 * Test non standalone `before` inline scripts attached to one the chain, of the two all scripts `defer` chains.
+	 * Test non-standalone `before` inline scripts attached to one the chain, of the two all scripts `defer` chains.
 	 *
 	 * If there are two dependency chains, rules are applied to the scripts in the chain that contain a `before` inline script.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_before_inline_script_on_multiple_defer_script_chain() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -611,6 +611,10 @@ EXP;
 	 * Test invalid defer loading strategy case.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_invalid_defer_registration() {
 		// Main script is defer and all dependent are not defer. Then main script will have blocking(or no) strategy.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -105,7 +105,7 @@ console.log("after two");
 </script>
 
 EXP;
-		$this->assertSame( $expected, $output, __( 'Inline scripts in the "after" position, both standalone and non standalone, are failing to print/execute or printing/executing in the incorrect order.' ) );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "after" position, both standalone and non standalone, are failing to print/execute or printing/executing in the incorrect order.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -159,13 +159,19 @@ EXP;
 	}
 
 	/**
-	 * Test non standalone inline scripts in the `after` position with deferred main script.
+	 * Test non-standalone inline scripts in the `after` position with deferred main script.
 	 *
 	 * If a main script with a `defer` loading strategy has an `after` inline script,
 	 * the inline script should be rendered as type='text/template'.
 	 * The common loader script should also be injected in this case.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_print_delayed_inline_script_loader
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_after_inline_script_with_defer_main_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -839,6 +839,10 @@ EXP;
 	 * Test script concatenation with blocking scripts before and after a `defer` script.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers ::wp_enqueue_script
+	 * @covers ::wp_register_script
 	 */
 	public function test_concatenate_with_blocking_script_before_and_after_script_with_defer_strategy() {
 		global $wp_scripts, $concatenate_scripts;

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -241,7 +241,7 @@ console.log("after one");
 </script>
 
 EXP;
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "after" position, that are non-standalone and attached to an async main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -251,6 +251,11 @@ EXP;
 	 * the inline script should be rendered as type='text/javascript'.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_after_inline_script_with_blocking_main_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -467,6 +467,11 @@ EXP;
 	 * strategy of the dependencies above it remains unchanged.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_standalone_before_inline_script_with_defer_dependency_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -507,7 +507,7 @@ EXP;
 		wp_enqueue_script( 'main-script-a1', '/main-script-a1.js', array(), null, array( 'strategy' => 'async' ) );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = "<script type='text/javascript' src='/main-script-a1.js' id='main-script-a1-js' async></script>\n";
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Scripts enqueued with an async loading strategy are failing to have the async attribute applied to the script handle when being printed.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -803,6 +803,10 @@ EXP;
 	 * Test script concatenation with `async` main script.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers ::wp_enqueue_script
+	 * @covers ::wp_register_script
 	 */
 	public function test_concatenate_with_async_strategy() {
 		global $wp_scripts, $concatenate_scripts;

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -653,6 +653,10 @@ EXP;
 	 * Test old and new in_footer logic.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_normalized_script_args
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_old_and_new_in_footer_scripts() {
 		// Scripts in head.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -363,12 +363,17 @@ EXP;
 	}
 
 	/**
-	 * Test non standalone `before` inline scripts attached to top most dependency in a all scripts `defer` chain.
+	 * Test non-standalone `before` inline scripts attached to top most dependency in an all scripts `defer` chain.
 	 *
 	 * If the top most dependency in the chain has a `before` inline script,
 	 * none of the scripts bellow it will be blocking.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_before_inline_script_on_top_most_dependency_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -706,7 +706,7 @@ EXP;
 			'strategy'  => 'async',
 		);
 		wp_enqueue_script( 'footer-async', '/footer-async.js', array(), null, $args );
-		$this->assertSame( $args, $wp_scripts->get_data( 'footer-async', 'script_args' ) );
+		$this->assertSame( $args, $wp_scripts->get_data( 'footer-async', 'script_args' ), 'Scripts args assigned to the $args parameter (such as the in_footer or strategy keys) are not being normalized correctly, the incorrect data shape is being returned.' );
 
 		// Test defaults.
 		$expected_args = array(
@@ -714,21 +714,21 @@ EXP;
 			'strategy'  => 'blocking',
 		);
 		wp_register_script( 'defaults-strategy', '/defaults.js', array(), null, array( 'in_footer' => true ) );
-		$this->assertSame( $expected_args, $wp_scripts->get_data( 'defaults-strategy', 'script_args' ) );
+		$this->assertSame( $expected_args, $wp_scripts->get_data( 'defaults-strategy', 'script_args' ), 'Scripts args assigned to the $args parameter (such as the in_footer key) are not being normalized correctly, the incorrect data shape is being returned.' );
 
 		$expected_args = array(
 			'in_footer' => false,
 			'strategy'  => 'async',
 		);
 		wp_register_script( 'defaults-in-footer', '/defaults.js', array(), null, array( 'strategy' => 'async' ) );
-		$this->assertSame( $expected_args, $wp_scripts->get_data( 'defaults-in-footer', 'script_args' ) );
+		$this->assertSame( $expected_args, $wp_scripts->get_data( 'defaults-in-footer', 'script_args' ), 'Scripts args assigned to the $args parameter (such as the strategy key) are not being normalized correctly, the incorrect data shape is being returned.' );
 
 		// scripts_args not set of args parameter is empty.
 		wp_register_script( 'empty-args-array', '/defaults.js', array(), null, array() );
-		$this->assertSame( false, $wp_scripts->get_data( 'defaults', 'script_args' ) );
+		$this->assertSame( false, $wp_scripts->get_data( 'defaults', 'script_args' ), 'Scripts args are not being normalized correctly when passing an empty array to the $args parameter, the incorrect data shape is being returned.' );
 
 		wp_register_script( 'no-args', '/defaults.js', array(), null );
-		$this->assertSame( false, $wp_scripts->get_data( 'defaults-no-args', 'script_args' ) );
+		$this->assertSame( false, $wp_scripts->get_data( 'defaults-no-args', 'script_args' ), 'Scripts args are not being normalized correctly when passing no $args parameter, the incorrect data shape is being returned.' );
 
 		// Test backward compatibility.
 		$expected_args = array(
@@ -736,7 +736,7 @@ EXP;
 			'strategy'  => 'blocking',
 		);
 		wp_enqueue_script( 'footer-old', '/footer-async.js', array(), null, true );
-		$this->assertSame( $expected_args, $wp_scripts->get_data( 'footer-old', 'script_args' ) );
+		$this->assertSame( $expected_args, $wp_scripts->get_data( 'footer-old', 'script_args' ), 'Scripts args assigned to the $args parameter (such as the in_footer or strategy keys) are not being normalized correctly, the incorrect data shape is being returned.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -797,7 +797,7 @@ EXP;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer></script>\n";
 
-		$this->assertSame( $expected, $print_scripts, 'Scripts are being incorrectly concatenated when a main script is registered with a "defer" loading strategy.' );
+		$this->assertSame( $expected, $print_scripts, 'Scripts are being incorrectly concatenated when a main script is registered with a "defer" loading strategy. Deferred scripts should not be part of the script concat loading query.' );
 	}
 
 	/**
@@ -833,7 +833,7 @@ EXP;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-async-script-1-js' async></script>\n";
 
-		$this->assertSame( $expected, $print_scripts );
+		$this->assertSame( $expected, $print_scripts, 'Scripts are being incorrectly concatenated when a main script is registered with an "async" loading strategy. Async scripts should not be part of the script concat loading query.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -394,7 +394,7 @@ EXP;
 	}
 
 	/**
-	 * Test non-standalone `before` inline scripts attached to one the chain, of the two all scripts `defer` chains.
+	 * Test non-standalone `before` inline scripts attached to one of two in the chain of an all scripts `defer` chain.
 	 *
 	 * If there are two dependency chains, rules are applied to the scripts in the chain that contain a `before` inline script.
 	 *
@@ -424,7 +424,7 @@ EXP;
 		$expected .= "<script type='text/javascript' src='http://example.org/ch2-ds-i4-2.js' id='ch2-ds-i4-2-js' defer></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.org/ms-i4-1.js' id='ms-i4-1-js' defer></script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "before" position, that are non-standalone and attached to one of two dependencies in an all scrips deferred chain, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -587,6 +587,10 @@ EXP;
 	 * Test valid defer loading with async dependent.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_defer_with_async_dependent() {
 		// case with one async dependent.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -497,6 +497,10 @@ EXP;
 	 * Test valid async loading strategy case.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_async_registration() {
 		// No dependents, No dependencies then async.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -539,6 +539,7 @@ EXP;
 	 * Test valid defer loading strategy cases.
 	 *
 	 * @ticket 12009
+	 *
 	 * @dataProvider data_loading_strategy_with_valid_defer_registration
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -761,7 +761,7 @@ EXP;
 
 		$expected = "<script type='text/javascript' src='/defaults.js' id='invalid-strategy-js'></script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Expected a blocking script strategy (default, no loading attributes printed) if an invalid loading strategy was assigned during script registration/enqueue.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -155,7 +155,7 @@ EXP;
 		$expected .= "<script type='text/javascript' id='ms-isa-2-js-after'>\n";
 		$expected .= "console.log(\"after one\");\n";
 		$expected .= "</script>\n";
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "after" position, that are standalone and attached to an async main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -767,6 +767,10 @@ EXP;
 	 * Test script concatenation with deferred main script.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers ::wp_enqueue_script
+	 * @covers ::wp_register_script
 	 */
 	public function test_concatenate_with_defer_strategy() {
 		global $wp_scripts, $concatenate_scripts;

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -872,7 +872,7 @@ EXP;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-2,two-concat-dep-2,three-concat-dep-2,four-concat-dep-2,five-concat-dep-2,six-concat-dep-2&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='deferred-script-2-js' defer></script>\n";
 
-		$this->assertSame( $expected, $print_scripts );
+		$this->assertSame( $expected, $print_scripts, 'Scripts are being incorrectly concatenated when a main script is registered as deferred after other blocking scripts are registered. Deferred scripts should not be part of the script concat loader query string. ' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -621,7 +621,6 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
-	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_async_registration() {
@@ -639,7 +638,6 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
-	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_invalid_async_registration() {
@@ -667,7 +665,6 @@ EXP;
 	 * @dataProvider data_loading_strategy_with_valid_defer_registration
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
-	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_defer_registration( $expected, $output, $message ) {
@@ -716,7 +713,6 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
-	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_defer_with_async_dependent() {
@@ -741,7 +737,6 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
-	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_invalid_defer_registration() {
@@ -762,7 +757,6 @@ EXP;
 	 *
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::get_eligible_loading_strategy
-	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_blocking_registration() {
@@ -784,7 +778,6 @@ EXP;
 	 * @ticket 12009
 	 *
 	 * @covers WP_Scripts::do_item
-	 * @covers WP_Scripts::get_normalized_script_args
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_old_and_new_in_footer_scripts() {

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -390,7 +390,7 @@ EXP;
 		$expected .= "<script type='text/javascript' src='http://example.org/ds-i3-2.js' id='ds-i3-2-js' defer></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.org/ms-i3-1.js' id='ms-i3-1-js' defer></script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "before" position, that are non-standalone and attached to the top most dependency in an all dependencies deferred chain, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -540,6 +540,9 @@ EXP;
 	 *
 	 * @ticket 12009
 	 * @dataProvider data_loading_strategy_with_valid_defer_registration
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_defer_registration( $expected, $output, $message ) {
 		$this->assertStringContainsString( $expected, $output, $message );

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -130,7 +130,7 @@ EXP;
 		$expected .= "<script type='text/javascript' id='ms-isa-1-js-after'>\n";
 		$expected .= "console.log(\"after one\");\n";
 		$expected .= "</script>\n";
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "after" position, that are standalone and attached to a deferred main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -331,7 +331,7 @@ EXP;
 	}
 
 	/**
-	 * Test non-standalone `before` inline scripts attached to a dependency scripts in a all scripts `defer` chain.
+	 * Test non-standalone `before` inline scripts attached to a dependency scripts in an all scripts `defer` chain.
 	 *
 	 * If any of the dependencies in the chain have a `before` inline script, all scripts above it should be blocking.
 	 *
@@ -359,7 +359,7 @@ EXP;
 		$expected .= "<script type='text/javascript' src='http://example.org/ds-i2-3.js' id='ds-i2-3-js' defer></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.org/ms-i2-1.js' id='ms-i2-1-js' defer></script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "before" position, that are non-standalone and attached to a deferred main scripts dependency chain, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -202,13 +202,19 @@ EXP;
 	}
 
 	/**
-	 * Test non standalone inline scripts in the `after` position with async main script.
+	 * Test non-standalone inline scripts in the `after` position with async main script.
 	 *
 	 * If a main script with an `async` loading strategy has an `after` inline script,
 	 * the inline script should be rendered as type='text/template'.
 	 * The common loader script should also be injected in this case.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_print_delayed_inline_script_loader
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_after_inline_script_with_async_main_script() {
 		unregister_all_script_handles();
@@ -239,7 +245,7 @@ EXP;
 	}
 
 	/**
-	 * Test non standalone inline scripts in the `after` position with blocking main script.
+	 * Test non-standalone inline scripts in the `after` position with blocking main script.
 	 *
 	 * If a main script with a `blocking` strategy has an `after` inline script,
 	 * the inline script should be rendered as type='text/javascript'.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -327,7 +327,7 @@ EXP;
 		$expected .= "</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.org/ms-i1-1.js' id='ms-i1-1-js' defer></script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "before" position, that are non-standalone and attached to a deferred main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -641,13 +641,13 @@ EXP;
 		wp_enqueue_script( 'main-script-b1', '/main-script-b1.js', array(), null, array( 'strategy' => 'blocking' ) );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = "<script type='text/javascript' src='/main-script-b1.js' id='main-script-b1-js'></script>\n";
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Scripts registered with a "blocking" strategy, and who have no dependencies, should have no loading strategy attributes printed.' );
 
 		// strategy args not set.
 		wp_enqueue_script( 'main-script-b2', '/main-script-b2.js', array(), null, array() );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = "<script type='text/javascript' src='/main-script-b2.js' id='main-script-b2-js'></script>\n";
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Scripts registered with no strategy assigned, and who have no dependencies, should have no loading strategy attributes printed.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -268,7 +268,7 @@ EXP;
 		$expected .= "console.log(\"after one\");\n";
 		$expected .= "</script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "after" position, that are non-standalone and attached to a blocking main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -115,6 +115,10 @@ EXP;
 	 * the inline script should not be affected.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_print_delayed_inline_script_loader
 	 */
 	public function test_standalone_after_inline_script_with_defer_main_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -692,6 +692,10 @@ EXP;
 	 * Test normalized script args.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_normalized_script_args
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_get_normalized_script_args() {
 		global $wp_scripts;

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -685,8 +685,8 @@ EXP;
 		$expected_footer .= "<script type='text/javascript' src='/enqueue-footer-old.js' id='enqueue-footer-old-js'></script>\n";
 		$expected_footer .= "<script type='text/javascript' src='/enqueue-footer-new.js' id='enqueue-footer-new-js'></script>\n";
 
-		$this->assertSame( $expected_header, $header );
-		$this->assertSame( $expected_footer, $footer );
+		$this->assertSame( $expected_header, $header, 'Scripts registered/enqueued using the older $in_footer parameter or the newer $args parameter should have the same outcome.' );
+		$this->assertSame( $expected_footer, $footer, 'Scripts registered/enqueued using the older $in_footer parameter or the newer $args parameter should have the same outcome.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -119,6 +119,7 @@ EXP;
 	 * @covers WP_Scripts::do_item
 	 * @covers WP_Scripts::print_inline_script
 	 * @covers ::wp_print_delayed_inline_script_loader
+	 * @covers ::wp_add_inline_script
 	 */
 	public function test_standalone_after_inline_script_with_defer_main_script() {
 		unregister_all_script_handles();
@@ -139,6 +140,11 @@ EXP;
 	 * the inline script should not be affected.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_print_delayed_inline_script_loader
+	 * @covers ::wp_add_inline_script
 	 */
 	public function test_standalone_after_inline_script_with_async_main_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -67,9 +67,13 @@ JS;
 	}
 
 	/**
-	 * Test standalone and non standalone inline scripts in the 'after' position of a single main script.
+	 * Test standalone and non-standalone inline scripts in the 'after' position of a single main script.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_print_delayed_inline_script_loader
 	 */
 	public function test_non_standalone_and_standalone_after_script_combined() {
 		// If a main script containing a `defer` strategy has an `after` inline script, the expected script type is type='javascript', otherwise type='text/template'.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -331,11 +331,16 @@ EXP;
 	}
 
 	/**
-	 * Test non standalone `before` inline scripts attached to a dependency scripts in a all scripts `defer` chain.
+	 * Test non-standalone `before` inline scripts attached to a dependency scripts in a all scripts `defer` chain.
 	 *
 	 * If any of the dependencies in the chain have a `before` inline script, all scripts above it should be blocking.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_before_inline_script_on_dependency_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -605,7 +605,7 @@ EXP;
 		$expected .= "<script type='text/javascript' src='/dependent-script-d4-2.js' id='dependent-script-d4-2-js' defer></script>\n";
 		$expected .= "<script type='text/javascript' src='/dependent-script-d4-3.js' id='dependent-script-d4-3-js' defer></script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Scripts registered as defer but that have dependents that are async are expected to have said dependents deferred.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -631,6 +631,10 @@ EXP;
 	 * Test valid blocking loading strategy cases.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::get_eligible_loading_strategy
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_valid_blocking_registration() {
 		wp_enqueue_script( 'main-script-b1', '/main-script-b1.js', array(), null, array( 'strategy' => 'blocking' ) );

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -272,12 +272,17 @@ EXP;
 	}
 
 	/**
-	 * Test non standalone inline scripts in the `after` position with deferred main script.
+	 * Test non-standalone inline scripts in the `after` position with deferred main script.
 	 *
 	 * If a main script with no loading strategy has an `after` inline script,
 	 * the inline script should be rendered as type='text/javascript'.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_after_inline_script_with_main_script_with_no_strategy() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -295,7 +295,7 @@ EXP;
 		$expected .= "console.log(\"after one\");\n";
 		$expected .= "</script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "after" position, that are non-standalone and attached to a deferred main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -457,7 +457,7 @@ EXP;
 		$expected .= "</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.org/ms-is1-1.js' id='ms-is1-1-js' defer></script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "before" position, that are standalone and attached to a deferred main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -490,7 +490,7 @@ EXP;
 		$expected .= "<script type='text/javascript' src='http://example.org/ds-is2-3.js' id='ds-is2-3-js' defer></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.org/ms-is2-1.js' id='ms-is2-1-js' defer></script>\n";
 
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "before" position, that are standalone and attached to a deferred main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -299,11 +299,16 @@ EXP;
 	}
 
 	/**
-	 * Test non standalone `before` inline scripts attached to deferred main scripts.
+	 * Test non-standalone `before` inline scripts attached to deferred main scripts.
 	 *
 	 * If the main script has a `before` inline script, all dependencies will be blocking.
 	 *
 	 * @ticket 12009
+	 *
+	 * @covers WP_Scripts::do_item
+	 * @covers WP_Scripts::print_inline_script
+	 * @covers ::wp_add_inline_script
+	 * @covers ::wp_enqueue_script
 	 */
 	public function test_non_standalone_before_inline_script_with_defer_main_script() {
 		unregister_all_script_handles();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -625,7 +625,7 @@ EXP;
 		wp_enqueue_script( 'dependent-script-d4-3', '/dependent-script-d4-3.js', array( 'dependent-script-d4-2' ), null, array( 'strategy' => 'defer' ) );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = "<script type='text/javascript' src='/main-script-d4.js' id='main-script-d4-js'></script>\n";
-		$this->assertStringContainsString( $expected, $output );
+		$this->assertStringContainsString( $expected, $output, 'Scripts registered as defer but that have all dependents with no strategy, should become blocking (no strategy).' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -797,7 +797,7 @@ EXP;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer></script>\n";
 
-		$this->assertSame( $expected, $print_scripts );
+		$this->assertSame( $expected, $print_scripts, 'Scripts are being incorrectly concatenated when a main script is registered with a "defer" loading strategy.');
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -198,7 +198,7 @@ console.log("after one");
 </script>
 
 EXP;
-		$this->assertSame( $expected, $output );
+		$this->assertSame( $expected, $output, 'Inline scripts in the "after" position, that are non-standalone and attached to a deferred main script, are failing to print/execute.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -148,10 +148,10 @@ EXP;
 	 */
 	public function test_standalone_after_inline_script_with_async_main_script() {
 		unregister_all_script_handles();
-		wp_enqueue_script( 'ms-isa-2', 'http://example.org/ms-isa-2.js', array(), null, array( 'strategy' => 'defer' ) );
+		wp_enqueue_script( 'ms-isa-2', 'http://example.org/ms-isa-2.js', array(), null, array( 'strategy' => 'async' ) );
 		wp_add_inline_script( 'ms-isa-2', 'console.log("after one");', 'after', true );
 		$output    = get_echo( 'wp_print_scripts' );
-		$expected  = "<script type='text/javascript' src='http://example.org/ms-isa-2.js' id='ms-isa-2-js' defer></script>\n";
+		$expected  = "<script type='text/javascript' src='http://example.org/ms-isa-2.js' id='ms-isa-2-js' async></script>\n";
 		$expected .= "<script type='text/javascript' id='ms-isa-2-js-after'>\n";
 		$expected .= "console.log(\"after one\");\n";
 		$expected .= "</script>\n";


### PR DESCRIPTION
Addresses PR feedback in https://github.com/WordPress/wordpress-develop/pull/4391 regarding adding `@covers` to test function doc blocks.
