### PR TITLE
Use `addEventListener` to catch script load events instead of `onload` event handler attribute

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -330,15 +330,6 @@ class WP_Scripts extends WP_Dependencies {
 					esc_attr( $handle ),
 					$after_non_standalone_script
 				);
-
-				// TODO: This won't work reliably for async.
-				$after_script .= wp_get_inline_script_tag(
-					sprintf(
-						'document.getElementById(%s).addEventListener("load", function(){wpLoadAfterScripts(%s)})',
-						wp_json_encode( "{$handle}-js" ),
-						wp_json_encode( "{$handle}" )
-					)
-				);
 			}
 		}
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -326,7 +326,7 @@ class WP_Scripts extends WP_Dependencies {
 
 			if ( $after_non_standalone_script ) {
 				$after_script .= sprintf(
-					"<script type='text/template' id='%1\$s-js-after' data-wp-executes-after='%1\$s'>\n%2\$s\n</script>\n",
+					"<script id='%1\$s-js-after' type='text/template' data-wp-executes-after='%1\$s'>\n%2\$s\n</script>\n",
 					esc_attr( $handle ),
 					$after_non_standalone_script
 				);

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -330,6 +330,15 @@ class WP_Scripts extends WP_Dependencies {
 					esc_attr( $handle ),
 					$after_non_standalone_script
 				);
+
+				// TODO: This won't work reliably for async.
+				$after_script .= wp_get_inline_script_tag(
+					sprintf(
+						'document.getElementById(%s).addEventListener("load", function(){wpLoadAfterScripts(%s)})',
+						wp_json_encode( "{$handle}-js" ),
+						wp_json_encode( "{$handle}" )
+					)
+				);
 			}
 		}
 
@@ -424,19 +433,13 @@ class WP_Scripts extends WP_Dependencies {
 			return true;
 		}
 
-		if ( '' !== $strategy ) {
-			$strategy = ' ' . $strategy;
-			if ( ! empty( $after_non_standalone_script ) ) {
-				$strategy .= sprintf( " onload='wpLoadAfterScripts(%s)'", esc_attr( wp_json_encode( $handle ) ) );
-			}
-		}
 		$tag  = $translations . $cond_before . $before_script;
 		$tag .= sprintf(
 			"<script%s src='%s' id='%s-js'%s></script>\n",
 			$this->type_attr,
 			esc_url( $src ),
 			esc_attr( $handle ),
-			$strategy
+			$strategy ? " {$strategy}" : ''
 		);
 		$tag .= $after_script . $cond_after;
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -303,38 +303,38 @@ class WP_Scripts extends WP_Dependencies {
 			$cond_after  = "<![endif]-->\n";
 		}
 
-		$before_handle = $this->print_inline_script( $handle, 'before', false );
+		$before_script = $this->print_inline_script( $handle, 'before', false );
 
-		if ( $before_handle ) {
-			$before_handle = sprintf( "<script%s id='%s-js-before'>\n%s\n</script>\n", $this->type_attr, esc_attr( $handle ), $before_handle );
+		if ( $before_script ) {
+			$before_script = sprintf( "<script%s id='%s-js-before'>\n%s\n</script>\n", $this->type_attr, esc_attr( $handle ), $before_script );
 		}
 
 		$strategy     = $this->get_eligible_loading_strategy( $handle );
 		$after        = ( 'defer' === $strategy || 'async' === $strategy ) ? 'after-standalone' : 'after';
-		$after_handle = $this->print_inline_script( $handle, $after, false );
+		$after_script = $this->print_inline_script( $handle, $after, false );
 
-		if ( $after_handle ) {
-			$after_handle = sprintf(
+		if ( $after_script ) {
+			$after_script = sprintf(
 				"<script%1\$s id='%2\$s-js-after'>\n%3\$s\n</script>\n",
 				$this->type_attr,
 				esc_attr( $handle ),
-				$after_handle
+				$after_script
 			);
 		}
 		if ( 'defer' === $strategy || 'async' === $strategy ) {
-			$after_non_standalone_handle = $this->print_inline_script( $handle, 'after-non-standalone', false );
+			$after_non_standalone_script = $this->print_inline_script( $handle, 'after-non-standalone', false );
 
-			if ( $after_non_standalone_handle ) {
-				$after_handle .= sprintf(
+			if ( $after_non_standalone_script ) {
+				$after_script .= sprintf(
 					"<script type='text/template' id='%1\$s-js-after' data-wp-executes-after='%1\$s'>\n%2\$s\n</script>\n",
 					esc_attr( $handle ),
-					$after_non_standalone_handle
+					$after_non_standalone_script
 				);
 			}
 		}
 
-		if ( $before_handle || $after_handle ) {
-			$inline_script_tag = $cond_before . $before_handle . $after_handle . $cond_after;
+		if ( $before_script || $after_script ) {
+			$inline_script_tag = $cond_before . $before_script . $after_script . $cond_after;
 		} else {
 			$inline_script_tag = '';
 		}
@@ -362,11 +362,11 @@ class WP_Scripts extends WP_Dependencies {
 			$srce = apply_filters( 'script_loader_src', $src, $handle );
 
 			// Used as a conditional to prevent script concatenation.
-			$is_deferred_or_async_handle = $this->is_non_blocking_strategy( $strategy );
+			$is_deferred_or_async = $this->is_non_blocking_strategy( $strategy );
 
 			if (
 				$this->in_default_dir( $srce )
-				&& ( $before_handle || $after_handle || $translations_stop_concat || $is_deferred_or_async_handle )
+				&& ( $before_script || $after_script || $translations_stop_concat || $is_deferred_or_async )
 			) {
 				$this->do_concat = false;
 
@@ -426,11 +426,11 @@ class WP_Scripts extends WP_Dependencies {
 
 		if ( '' !== $strategy ) {
 			$strategy = ' ' . $strategy;
-			if ( ! empty( $after_non_standalone_handle ) ) {
+			if ( ! empty( $after_non_standalone_script ) ) {
 				$strategy .= sprintf( " onload='wpLoadAfterScripts(%s)'", esc_attr( wp_json_encode( $handle ) ) );
 			}
 		}
-		$tag  = $translations . $cond_before . $before_handle;
+		$tag  = $translations . $cond_before . $before_script;
 		$tag .= sprintf(
 			"<script%s src='%s' id='%s-js'%s></script>\n",
 			$this->type_attr,
@@ -438,7 +438,7 @@ class WP_Scripts extends WP_Dependencies {
 			esc_attr( $handle ),
 			$strategy
 		);
-		$tag .= $after_handle . $cond_after;
+		$tag .= $after_script . $cond_after;
 
 		/**
 		 * Filters the HTML script tag of an enqueued script.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -81,13 +81,31 @@ JS;
 		$expected = <<<EXP
 <script type="text/javascript" id="wp-executes-after-js">
 (function () {
-  // Capture the nonce of the currentScript so we can use it when evaluating after inline scripts.
   var nonce = document.currentScript.nonce;
 
-  window.wpLoadAfterScripts = function wpLoadAfterScripts(handle) {
-    var scripts, newScript, i, len;
+  /**
+   * Load event handler.
+   *
+   * @param {Event} event Event.
+   */
+  function onScriptLoad(event) {
+    var i, len, newScript, matches, scripts;
+    if (
+      !(
+        event.target instanceof HTMLScriptElement ||
+        event.target.async ||
+        event.target.defer ||
+        event.target.id
+      )
+    ) {
+      return;
+    }
+    matches = event.target.id.match(/^(.+)-js$/);
+    if (!matches) {
+      return;
+    }
     scripts = document.querySelectorAll(
-      '[type="text/template"][data-wp-executes-after="' + handle + '"]'
+      '[type="text/template"][data-wp-executes-after="' + matches[1] + '"]'
     );
     for (i = 0, len = scripts.length; i < len; i++) {
       if (nonce && nonce !== scripts[i].nonce) {
@@ -101,14 +119,23 @@ JS;
       newScript.type = "text/javascript";
       scripts[i].parentNode.replaceChild(newScript, scripts[i]);
     }
-  };
+  }
+  document.addEventListener("load", onScriptLoad, true);
+
+  window.addEventListener(
+    "load",
+    () => {
+      document.removeEventListener("load", onScriptLoad, true);
+    },
+    { once: true }
+  );
 })();
 </script>
-<script type='text/javascript' src='http://example.org/ms-isinsa-1.js' id='ms-isinsa-1-js' defer onload='wpLoadAfterScripts(&quot;ms-isinsa-1&quot;)'></script>
+<script type='text/javascript' src='http://example.org/ms-isinsa-1.js' id='ms-isinsa-1-js' defer></script>
 <script type='text/javascript' id='ms-isinsa-1-js-after'>
 console.log("after one");
 </script>
-<script type='text/template' id='ms-isinsa-1-js-after' data-wp-executes-after='ms-isinsa-1'>
+<script id='ms-isinsa-1-js-after' type='text/template' data-wp-executes-after='ms-isinsa-1'>
 console.log("after two");
 </script>
 
@@ -173,13 +200,31 @@ EXP;
 		$expected = <<<EXP
 <script type="text/javascript" id="wp-executes-after-js">
 (function () {
-  // Capture the nonce of the currentScript so we can use it when evaluating after inline scripts.
   var nonce = document.currentScript.nonce;
 
-  window.wpLoadAfterScripts = function wpLoadAfterScripts(handle) {
-    var scripts, newScript, i, len;
+  /**
+   * Load event handler.
+   *
+   * @param {Event} event Event.
+   */
+  function onScriptLoad(event) {
+    var i, len, newScript, matches, scripts;
+    if (
+      !(
+        event.target instanceof HTMLScriptElement ||
+        event.target.async ||
+        event.target.defer ||
+        event.target.id
+      )
+    ) {
+      return;
+    }
+    matches = event.target.id.match(/^(.+)-js$/);
+    if (!matches) {
+      return;
+    }
     scripts = document.querySelectorAll(
-      '[type="text/template"][data-wp-executes-after="' + handle + '"]'
+      '[type="text/template"][data-wp-executes-after="' + matches[1] + '"]'
     );
     for (i = 0, len = scripts.length; i < len; i++) {
       if (nonce && nonce !== scripts[i].nonce) {
@@ -193,11 +238,20 @@ EXP;
       newScript.type = "text/javascript";
       scripts[i].parentNode.replaceChild(newScript, scripts[i]);
     }
-  };
+  }
+  document.addEventListener("load", onScriptLoad, true);
+
+  window.addEventListener(
+    "load",
+    () => {
+      document.removeEventListener("load", onScriptLoad, true);
+    },
+    { once: true }
+  );
 })();
 </script>
-<script type='text/javascript' src='http://example.org/ms-insa-1.js' id='ms-insa-1-js' defer onload='wpLoadAfterScripts(&quot;ms-insa-1&quot;)'></script>
-<script type='text/template' id='ms-insa-1-js-after' data-wp-executes-after='ms-insa-1'>
+<script type='text/javascript' src='http://example.org/ms-insa-1.js' id='ms-insa-1-js' defer></script>
+<script id='ms-insa-1-js-after' type='text/template' data-wp-executes-after='ms-insa-1'>
 console.log("after one");
 </script>
 
@@ -222,13 +276,31 @@ EXP;
 		$expected = <<<EXP
 <script type="text/javascript" id="wp-executes-after-js">
 (function () {
-  // Capture the nonce of the currentScript so we can use it when evaluating after inline scripts.
   var nonce = document.currentScript.nonce;
 
-  window.wpLoadAfterScripts = function wpLoadAfterScripts(handle) {
-    var scripts, newScript, i, len;
+  /**
+   * Load event handler.
+   *
+   * @param {Event} event Event.
+   */
+  function onScriptLoad(event) {
+    var i, len, newScript, matches, scripts;
+    if (
+      !(
+        event.target instanceof HTMLScriptElement ||
+        event.target.async ||
+        event.target.defer ||
+        event.target.id
+      )
+    ) {
+      return;
+    }
+    matches = event.target.id.match(/^(.+)-js$/);
+    if (!matches) {
+      return;
+    }
     scripts = document.querySelectorAll(
-      '[type="text/template"][data-wp-executes-after="' + handle + '"]'
+      '[type="text/template"][data-wp-executes-after="' + matches[1] + '"]'
     );
     for (i = 0, len = scripts.length; i < len; i++) {
       if (nonce && nonce !== scripts[i].nonce) {
@@ -242,11 +314,20 @@ EXP;
       newScript.type = "text/javascript";
       scripts[i].parentNode.replaceChild(newScript, scripts[i]);
     }
-  };
+  }
+  document.addEventListener("load", onScriptLoad, true);
+
+  window.addEventListener(
+    "load",
+    () => {
+      document.removeEventListener("load", onScriptLoad, true);
+    },
+    { once: true }
+  );
 })();
 </script>
-<script type='text/javascript' src='http://example.org/ms-insa-2.js' id='ms-insa-2-js' async onload='wpLoadAfterScripts(&quot;ms-insa-2&quot;)'></script>
-<script type='text/template' id='ms-insa-2-js-after' data-wp-executes-after='ms-insa-2'>
+<script type='text/javascript' src='http://example.org/ms-insa-2.js' id='ms-insa-2-js' async></script>
+<script id='ms-insa-2-js-after' type='text/template' data-wp-executes-after='ms-insa-2'>
 console.log("after one");
 </script>
 


### PR DESCRIPTION
Extends https://github.com/WordPress/wordpress-develop/pull/4391

This fixes the need to use the `'unsafe-hashes'` CSP source expression as [explained in the other PR](https://github.com/WordPress/wordpress-develop/pull/4391#issuecomment-1536869109:~:text=Strict%20CSP%20Blocked%20by%20unsafe%2Dhashes%20Requirement). 

Instead of attaching a `load` event listener to every `script` on the page, it instead adds a single _capturing_ `load` event listener on the `document`. The benefit here is it will reliably catch the loading of `async` scripts, versus other alternatives seen in: https://westonruter.github.io/async-script-load-listeners/

Another benefit of this is we no longer pollute the global namespace with `wpLoadAfterScripts`.