### PR TITLE
Flatten `script_args` data in favor of `group` and `strategy` script data

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -849,12 +849,14 @@ JS;
 	 * @since 6.3.0
 	 *
 	 * @param string $handle The script handle.
-	 * @return string Strategy set during script registration. Empty string if none was set.
+	 * @return string Strategy set during script registration. Empty string if none was set or it was invalid.
 	 */
 	private function get_intended_strategy( $handle ) {
 		$strategy = $this->get_data( $handle, 'strategy' );
 
-		if ( $strategy && ! $this->is_valid_strategy( $strategy ) ) {
+		if ( ! $strategy ) {
+			$strategy = '';
+		} elseif ( ! $this->is_valid_strategy( $strategy ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
@@ -866,7 +868,7 @@ JS;
 				'6.3.0'
 			);
 
-			return '';
+			$strategy = '';
 		}
 
 		return $strategy;

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -784,27 +784,6 @@ JS;
 	}
 
 	/**
-	 * Checks all handles for any delayed inline scripts.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @return bool True if the inline script present, otherwise false.
-	 */
-	public function has_delayed_inline_script() {
-		foreach ( $this->registered as $handle => $script ) {
-			// Non-standalone scripts in the after position, of type async or defer, are usually delayed.
-			$strategy = $this->get_data( $handle, 'strategy' );
-			if (
-				$this->is_non_blocking_strategy( $strategy )
-				&& $this->has_non_standalone_inline_script( $handle, 'after' )
-			) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * This overrides the add_data method from WP_Dependencies, to support normalizing of $args.
 	 *
 	 * @since 6.3.0
@@ -829,6 +808,27 @@ JS;
 			return false;
 		}
 		return parent::add_data( $handle, $key, $value );
+	}
+
+	/**
+	 * Checks all handles for any delayed inline scripts.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @return bool True if the inline script present, otherwise false.
+	 */
+	public function has_delayed_inline_script() {
+		foreach ( $this->registered as $handle => $script ) {
+			// Non-standalone scripts in the after position, of type async or defer, are usually delayed.
+			$strategy = $this->get_data( $handle, 'strategy' );
+			if (
+				$this->is_non_blocking_strategy( $strategy )
+				&& $this->has_non_standalone_inline_script( $handle, 'after' )
+			) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -781,27 +781,6 @@ JS;
 	}
 
 	/**
-	 * This overrides the add_data method from WP_Dependencies, to support normalizing of $args.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @param string $handle Name of the item. Should be unique.
-	 * @param string $key    The data key.
-	 * @param mixed  $value  The data value.
-	 * @return bool True on success, false on failure.
-	 */
-	public function add_data( $handle, $key, $value ) {
-		if ( 'script_args' === $key ) {
-			$args = $this->get_normalized_script_args( $handle, $value );
-			if ( $args['in_footer'] ) {
-				parent::add_data( $handle, 'group', 1 );
-			}
-			return parent::add_data( $handle, $key, $args );
-		}
-		return parent::add_data( $handle, $key, $value );
-	}
-
-	/**
 	 * Checks all handles for any delayed inline scripts.
 	 *
 	 * @since 6.3.0
@@ -819,34 +798,6 @@ JS;
 			}
 		}
 		return false;
-	}
-
-	/**
-	 * Normalize the data inside the $args parameter and support backward compatibility.
-	 *
-	 * @since 6.3.0
-	 *
-	 * @param string        $handle Name of the script.
-	 * @param array         $args     {
-	 *      Optional. Additional script arguments. Default empty array.
-	 *
-	 *      @type boolean   $in_footer    Optional. Default false.
-	 *      @type string    $strategy     Optional. Values blocking|defer|async. Default 'blocking'.
-	 * }
-	 * @return array        Normalized $args array.
-	 */
-	private function get_normalized_script_args( $handle, $args = array() ) {
-		$default_args = array(
-			'in_footer' => false,
-			'strategy'  => 'blocking',
-		);
-
-		// Handle backward compatibility for $in_footer.
-		if ( true === $args ) {
-			$args = array( 'in_footer' => true );
-		}
-
-		return wp_parse_args( $args, $default_args );
 	}
 
 	/**
@@ -901,8 +852,7 @@ JS;
 	 * @return string Strategy set during script registration. Empty string if none was set.
 	 */
 	private function get_intended_strategy( $handle ) {
-		$script_args = $this->get_data( $handle, 'script_args' );
-		$strategy    = isset( $script_args['strategy'] ) ? $script_args['strategy'] : '';
+		$strategy = $this->get_data( $handle, 'strategy' );
 
 		if ( $strategy && ! $this->is_valid_strategy( $strategy ) ) {
 			_doing_it_wrong(

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -181,15 +181,6 @@ function wp_register_script( $handle, $src, $deps = array(), $ver = false, $args
 	if ( ! is_array( $args ) ) {
 		$args = array(
 			'in_footer' => $args,
-			'strategy'  => 'blocking',
-		);
-	} else {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'in_footer' => false,
-				'strategy'  => 'blocking',
-			)
 		);
 	}
 	_wp_scripts_maybe_doing_it_wrong( __FUNCTION__, $handle );
@@ -382,14 +373,6 @@ function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $
 		if ( ! is_array( $args ) ) {
 			$args = array(
 				'in_footer' => $args,
-			);
-		} else {
-			$args = wp_parse_args(
-				$args,
-				array(
-					'in_footer' => false,
-					'strategy'  => 'blocking',
-				)
 			);
 		}
 

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -180,7 +180,7 @@ function wp_add_inline_script( $handle, $data, $position = 'after', $standalone 
 function wp_register_script( $handle, $src, $deps = array(), $ver = false, $args = array() ) {
 	if ( ! is_array( $args ) ) {
 		$args = array(
-			'in_footer' => $args,
+			'in_footer' => (bool) $args,
 		);
 	}
 	_wp_scripts_maybe_doing_it_wrong( __FUNCTION__, $handle );
@@ -372,7 +372,7 @@ function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $
 		$_handle = explode( '?', $handle );
 		if ( ! is_array( $args ) ) {
 			$args = array(
-				'in_footer' => $args,
+				'in_footer' => (bool) $args,
 			);
 		}
 

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -178,13 +178,30 @@ function wp_add_inline_script( $handle, $data, $position = 'after', $standalone 
  * @return bool Whether the script has been registered. True on success, false on failure.
  */
 function wp_register_script( $handle, $src, $deps = array(), $ver = false, $args = array() ) {
+	if ( ! is_array( $args ) ) {
+		$args = array(
+			'in_footer' => $args,
+			'strategy'  => 'blocking',
+		);
+	} else {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'in_footer' => false,
+				'strategy'  => 'blocking',
+			)
+		);
+	}
 	_wp_scripts_maybe_doing_it_wrong( __FUNCTION__, $handle );
 
 	$wp_scripts = wp_scripts();
 
 	$registered = $wp_scripts->add( $handle, $src, $deps, $ver );
-	if ( ! empty( $args ) ) {
-		$wp_scripts->add_data( $handle, 'script_args', $args );
+	if ( ! empty( $args['in_footer'] ) ) {
+		$wp_scripts->add_data( $handle, 'group', 1 );
+	}
+	if ( ! empty( $args['strategy'] ) ) {
+		$wp_scripts->add_data( $handle, 'strategy', $args['strategy'] );
 	}
 	return $registered;
 }
@@ -362,12 +379,28 @@ function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $
 
 	if ( $src || ! empty( $args ) ) {
 		$_handle = explode( '?', $handle );
+		if ( ! is_array( $args ) ) {
+			$args = array(
+				'in_footer' => $args,
+			);
+		} else {
+			$args = wp_parse_args(
+				$args,
+				array(
+					'in_footer' => false,
+					'strategy'  => 'blocking',
+				)
+			);
+		}
 
 		if ( $src ) {
 			$wp_scripts->add( $_handle[0], $src, $deps, $ver );
 		}
-		if ( ! empty( $args ) ) {
-			$wp_scripts->add_data( $_handle[0], 'script_args', $args );
+		if ( ! empty( $args['in_footer'] ) ) {
+			$wp_scripts->add_data( $_handle[0], 'group', 1 );
+		}
+		if ( ! empty( $args['strategy'] ) ) {
+			$wp_scripts->add_data( $_handle[0], 'strategy', $args['strategy'] );
 		}
 	}
 

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -168,10 +168,12 @@ function wp_add_inline_script( $handle, $data, $position = 'after', $standalone 
  *                                    as a query string for cache busting purposes. If version is set to false, a version
  *                                    number is automatically added equal to current installed WordPress version.
  *                                    If set to null, no version is added.
- * @param array             $args     {
+ * @param array|bool       $args     {
  *      Optional. An array of additional script loading strategies. Default empty array.
+ *      Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
  *
  *      @type string    $strategy     Optional. Values blocking|defer|async. Default 'blocking'.
+ *      @type bool      $in_footer    Optional. Whether to print the script in the footer. Default 'false'.
  * }
  * @return bool Whether the script has been registered. True on success, false on failure.
  */
@@ -345,11 +347,12 @@ function wp_deregister_script( $handle ) {
  *                                    as a query string for cache busting purposes. If version is set to false, a version
  *                                    number is automatically added equal to current installed WordPress version.
  *                                    If set to null, no version is added.
- * @param array            $args      {
+ * @param array|bool       $args     {
  *      Optional. An array of additional script loading strategies. Default empty array.
+ *      Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
  *
- *      @type boolean   $in_footer    Optional. Default false.
  *      @type string    $strategy     Optional. Values blocking|defer|async. Default 'blocking'.
+ *      @type bool      $in_footer    Optional. Whether to print the script in the footer. Default 'false'.
  * }
  */
 function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $args = array() ) {

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -816,6 +816,7 @@ EXP;
 	 *
 	 * @covers WP_Scripts::add_data
 	 * @covers ::wp_register_script
+	 * @covers ::wp_enqueue_script
 	 * @ticket 12009
 	 */
 	public function test_script_strategy_doing_it_wrong_via_register() {
@@ -836,7 +837,9 @@ EXP;
 	 * For an invalid strategy defined during script registration, default to a blocking strategy.
 	 *
 	 * @covers WP_Scripts::add_data
+	 * @covers ::wp_script_add_data
 	 * @covers ::wp_register_script
+	 * @covers ::wp_enqueue_script
 	 * @ticket 12009
 	 */
 	public function test_script_strategy_doing_it_wrong_via_add_data() {

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -756,23 +756,66 @@ EXP;
 	}
 
 	/**
-	 * Test script strategy doing it wrong.
+	 * Test script strategy doing it wrong when calling wp_register_script().
 	 *
 	 * For an invalid strategy defined during script registration, default to a blocking strategy.
 	 *
+	 * @covers WP_Scripts::add_data
+	 * @covers ::wp_register_script
 	 * @ticket 12009
 	 */
-	public function test_script_strategy_doing_it_wrong() {
+	public function test_script_strategy_doing_it_wrong_via_register() {
 		$this->setExpectedIncorrectUsage( 'WP_Scripts::add_data' );
 
 		wp_register_script( 'invalid-strategy', '/defaults.js', array(), null, array( 'strategy' => 'random-strategy' ) );
 		wp_enqueue_script( 'invalid-strategy' );
 
-		$output = get_echo( 'wp_print_scripts' );
+		$this->assertSame(
+			"<script type='text/javascript' src='/defaults.js' id='invalid-strategy-js'></script>\n",
+			get_echo( 'wp_print_scripts' )
+		);
+	}
 
-		$expected = "<script type='text/javascript' src='/defaults.js' id='invalid-strategy-js'></script>\n";
+	/**
+	 * Test script strategy doing it wrong when calling wp_script_add_data().
+	 *
+	 * For an invalid strategy defined during script registration, default to a blocking strategy.
+	 *
+	 * @covers WP_Scripts::add_data
+	 * @covers ::wp_register_script
+	 * @ticket 12009
+	 */
+	public function test_script_strategy_doing_it_wrong_via_add_data() {
+		$this->setExpectedIncorrectUsage( 'WP_Scripts::add_data' );
 
-		$this->assertSame( $expected, $output );
+		wp_register_script( 'invalid-strategy', '/defaults.js', array(), null );
+		wp_script_add_data( 'invalid-strategy', 'strategy', 'random-strategy' );
+		wp_enqueue_script( 'invalid-strategy' );
+
+		$this->assertSame(
+			"<script type='text/javascript' src='/defaults.js' id='invalid-strategy-js'></script>\n",
+			get_echo( 'wp_print_scripts' )
+		);
+	}
+
+	/**
+	 * Test script strategy doing it wrong when calling wp_register_script().
+	 *
+	 * For an invalid strategy defined during script registration, default to a blocking strategy.
+	 *
+	 * @covers WP_Scripts::add_data
+	 * @covers ::wp_enqueue_script
+	 * @ticket 12009
+	 */
+	public function test_script_strategy_doing_it_wrong_via_enqueue() {
+		$this->setExpectedIncorrectUsage( 'WP_Scripts::add_data' );
+
+		wp_enqueue_script( 'invalid-strategy', '/defaults.js', array(), null, array( 'strategy' => 'random-strategy' ) );
+
+		$this->assertSame(
+			"<script type='text/javascript' src='/defaults.js' id='invalid-strategy-js'></script>\n",
+			get_echo( 'wp_print_scripts' )
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -638,6 +638,8 @@ EXP;
 	 */
 	public function test_get_normalized_script_args() {
 		global $wp_scripts;
+
+		// Passing in_footer and strategy via args array.
 		$args = array(
 			'in_footer' => true,
 			'strategy'  => 'async',
@@ -646,36 +648,30 @@ EXP;
 		$this->assertSame( $args['in_footer'], (bool) $wp_scripts->get_data( 'footer-async', 'group' ) );
 		$this->assertSame( $args['strategy'], $wp_scripts->get_data( 'footer-async', 'strategy' ) );
 
-		// Test defaults.
-		$expected_args = array(
-			'in_footer' => true,
-			'strategy'  => 'blocking',
-		);
+		// Passing in_footer=true via array.
 		wp_register_script( 'defaults-strategy', '/defaults.js', array(), null, array( 'in_footer' => true ) );
-		$this->assertSame( $expected_args['in_footer'], (bool) $wp_scripts->get_data( 'defaults-strategy', 'group' ) );
-		$this->assertSame( $expected_args['strategy'], $wp_scripts->get_data( 'defaults-strategy', 'strategy' ) );
+		$this->assertSame( 1, $wp_scripts->get_data( 'defaults-strategy', 'group' ) );
+		$this->assertFalse( $wp_scripts->get_data( 'defaults-strategy', 'strategy' ) );
 
-		$expected_args = array(
-			'in_footer' => false,
-			'strategy'  => 'async',
-		);
+		// Passing async strategy.
 		wp_register_script( 'defaults-in-footer', '/defaults.js', array(), null, array( 'strategy' => 'async' ) );
-		$this->assertSame( $expected_args['in_footer'], (bool) $wp_scripts->get_data( 'defaults-in-footer', 'group' ) );
-		$this->assertSame( $expected_args['strategy'], $wp_scripts->get_data( 'defaults-in-footer', 'strategy' ) );
+		$this->assertFalse( $wp_scripts->get_data( 'defaults-in-footer', 'group' ) );
+		$this->assertSame( 'async', $wp_scripts->get_data( 'defaults-in-footer', 'strategy' ) );
 
-		// scripts_args not set of args parameter is empty.
+		// Passing empty array as 5th arg.
 		wp_register_script( 'empty-args-array', '/defaults.js', array(), null, array() );
-		$this->assertSame( false, $wp_scripts->get_data( 'empty-args-array', 'group' ) );
-		$this->assertSame( 'blocking', $wp_scripts->get_data( 'empty-args-array', 'strategy' ) );
+		$this->assertFalse( $wp_scripts->get_data( 'empty-args-array', 'group' ) );
+		$this->assertFalse( $wp_scripts->get_data( 'empty-args-array', 'strategy' ) );
 
+		// Test passing no 5th arg at all.
 		wp_register_script( 'no-args', '/defaults.js', array(), null );
-		$this->assertSame( false, $wp_scripts->get_data( 'no-args', 'group' ) );
-		$this->assertSame( 'blocking', $wp_scripts->get_data( 'no-args', 'strategy' ) );
+		$this->assertFalse( $wp_scripts->get_data( 'no-args', 'group' ) );
+		$this->assertFalse( $wp_scripts->get_data( 'no-args', 'strategy' ) );
 
-		// Test backward compatibility.
+		// Test backward compatibility, passing $in_footer=true as 5th arg.
 		wp_enqueue_script( 'footer-old', '/footer-async.js', array(), null, true );
 		$this->assertSame( 1, $wp_scripts->get_data( 'footer-old', 'group' ) );
-		$this->assertSame( false, $wp_scripts->get_data( 'footer-old', 'strategy' ) );
+		$this->assertFalse( $wp_scripts->get_data( 'footer-old', 'strategy' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -645,7 +645,7 @@ EXP;
 			'strategy'  => 'async',
 		);
 		wp_enqueue_script( 'footer-async', '/footer-async.js', array(), null, $args );
-		$this->assertSame( $args['in_footer'], (bool) $wp_scripts->get_data( 'footer-async', 'group' ) );
+		$this->assertSame( 1, $wp_scripts->get_data( 'footer-async', 'group' ) );
 		$this->assertSame( $args['strategy'], $wp_scripts->get_data( 'footer-async', 'strategy' ) );
 
 		// Passing in_footer=true via array.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -856,7 +856,7 @@ EXP;
 	}
 
 	/**
-	 * Test script strategy doing it wrong when calling wp_register_script().
+	 * Test script strategy doing it wrong when calling wp_enqueue_script().
 	 *
 	 * For an invalid strategy defined during script registration, default to a blocking strategy.
 	 *

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -763,7 +763,7 @@ EXP;
 	 * @ticket 12009
 	 */
 	public function test_script_strategy_doing_it_wrong() {
-		$this->setExpectedIncorrectUsage( 'WP_Scripts::get_intended_strategy' );
+		$this->setExpectedIncorrectUsage( 'WP_Scripts::add_data' );
 
 		wp_register_script( 'invalid-strategy', '/defaults.js', array(), null, array( 'strategy' => 'random-strategy' ) );
 		wp_enqueue_script( 'invalid-strategy' );

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -643,7 +643,8 @@ EXP;
 			'strategy'  => 'async',
 		);
 		wp_enqueue_script( 'footer-async', '/footer-async.js', array(), null, $args );
-		$this->assertSame( $args, $wp_scripts->get_data( 'footer-async', 'script_args' ) );
+		$this->assertSame( $args['in_footer'], (bool) $wp_scripts->get_data( 'footer-async', 'group' ) );
+		$this->assertSame( $args['strategy'], $wp_scripts->get_data( 'footer-async', 'strategy' ) );
 
 		// Test defaults.
 		$expected_args = array(
@@ -651,29 +652,30 @@ EXP;
 			'strategy'  => 'blocking',
 		);
 		wp_register_script( 'defaults-strategy', '/defaults.js', array(), null, array( 'in_footer' => true ) );
-		$this->assertSame( $expected_args, $wp_scripts->get_data( 'defaults-strategy', 'script_args' ) );
+		$this->assertSame( $expected_args['in_footer'], (bool) $wp_scripts->get_data( 'defaults-strategy', 'group' ) );
+		$this->assertSame( $expected_args['strategy'], $wp_scripts->get_data( 'defaults-strategy', 'strategy' ) );
 
 		$expected_args = array(
 			'in_footer' => false,
 			'strategy'  => 'async',
 		);
 		wp_register_script( 'defaults-in-footer', '/defaults.js', array(), null, array( 'strategy' => 'async' ) );
-		$this->assertSame( $expected_args, $wp_scripts->get_data( 'defaults-in-footer', 'script_args' ) );
+		$this->assertSame( $expected_args['in_footer'], (bool) $wp_scripts->get_data( 'defaults-in-footer', 'group' ) );
+		$this->assertSame( $expected_args['strategy'], $wp_scripts->get_data( 'defaults-in-footer', 'strategy' ) );
 
 		// scripts_args not set of args parameter is empty.
 		wp_register_script( 'empty-args-array', '/defaults.js', array(), null, array() );
-		$this->assertSame( false, $wp_scripts->get_data( 'defaults', 'script_args' ) );
+		$this->assertSame( false, $wp_scripts->get_data( 'empty-args-array', 'group' ) );
+		$this->assertSame( 'blocking', $wp_scripts->get_data( 'empty-args-array', 'strategy' ) );
 
 		wp_register_script( 'no-args', '/defaults.js', array(), null );
-		$this->assertSame( false, $wp_scripts->get_data( 'defaults-no-args', 'script_args' ) );
+		$this->assertSame( false, $wp_scripts->get_data( 'no-args', 'group' ) );
+		$this->assertSame( 'blocking', $wp_scripts->get_data( 'no-args', 'strategy' ) );
 
 		// Test backward compatibility.
-		$expected_args = array(
-			'in_footer' => true,
-			'strategy'  => 'blocking',
-		);
 		wp_enqueue_script( 'footer-old', '/footer-async.js', array(), null, true );
-		$this->assertSame( $expected_args, $wp_scripts->get_data( 'footer-old', 'script_args' ) );
+		$this->assertSame( 1, $wp_scripts->get_data( 'footer-old', 'group' ) );
+		$this->assertSame( false, $wp_scripts->get_data( 'footer-old', 'strategy' ) );
 	}
 
 	/**


### PR DESCRIPTION
Amends https://github.com/WordPress/wordpress-develop/pull/4391

This addresses a [suggestion I made](https://github.com/WordPress/wordpress-develop/pull/4391/files#r1197166624) to remove the `script_args` script data. Instead, it preserves the original use of the `group` data to represent `in_footer`, and it introduces a top-level `strategy` data key. This eliminates data duplication between `data.group` and `data.script_args.in_footer`. This improves backwards-compatibility for plugins that are directly mutating `group` which don't know about `script_args`. Another benefit here is we can remove the overloaded `add_data` method and remove the `get_normalized_script_args` helper method.

This PR also updates the `get_intended_strategy` method to ensure that it returns an empty string in case an invalid strategy (or no strategy was supplied). 

The phpdoc for the 5th argument to `wp_register_script()`/`wp_enqueue_script()` has also been updated to reflect that you can still pass a `bool` instead of an `array`.

Tests are passing.